### PR TITLE
Add CLI command to download bolt artifacts

### DIFF
--- a/paradime/cli/rich_text_output.py
+++ b/paradime/cli/rich_text_output.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 
 import click
 from rich import box
@@ -59,3 +60,15 @@ def print_run_status(status: str, json: bool) -> None:
     if json:
         return
     console.print(Text(f"\n✨ Current run status: {status}"))
+
+
+def print_artifact_downloading(*, schedule_name: str, artifact_path: str) -> None:
+    console.print(
+        Text(
+            f"\n⬇️  Downloading the latest artifact located at {artifact_path!r} from schedule {schedule_name!r}..."
+        )
+    )
+
+
+def print_artifact_downloaded(artifact_path: Path) -> None:
+    console.print(Text(f"\n📦 Artifact downloaded to {artifact_path.absolute().as_posix()!r}."))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "paradime-io"
-version = "4.5.0"
+version = "4.6.0"
 description = "Paradime - Python SDK"
 authors = ["Bhuvan Singla <bhuvan@paradime.io>", "Maximilian Mitchell <max@paradime.io>"]
 readme = "README.md"


### PR DESCRIPTION
This pull request introduces a new artifact command to the Paradime CLI that lets users download the latest artifact from a specified Paradime Bolt schedule

### Command Description
Example:
```sh
paradime bolt artifact --schedule-name "daily_run"
```
**Options**:
- `--schedule-name`: (Required) Name of the Bolt schedule.
- `--artifact-path`: (Default: `target/manifest.json`) Path to the artifact in the Bolt run.
- `--command-index`: (Optional) Index of the command in the schedule.
- `--output-path`: (Optional) Path to save the artifact (default: current directory).

### Additional Changes
- Updates version to 4.6.0
