### PR TITLE
Tableau CLI: Set site name parameter as optional

### DIFF
--- a/paradime/cli/run.py
+++ b/paradime/cli/run.py
@@ -29,6 +29,9 @@ def run() -> None:
 @env_click_option(
     "site-name",
     "TABLEAU_SITE_NAME",
+    help="The name of the tableau site. Set this only if you are using a site other than the default site.",
+    required=False,
+    default="",
 )
 @env_click_option(
     "workbook-name",
@@ -67,7 +70,7 @@ def tableau_refresh(
         host=host,
         personal_access_token_name=personal_access_token_name,
         personal_access_token_secret=personal_access_token_secret,
-        site_name=site_name,
+        site_name=site_name or "",
         workbook_names=workbook_name,
         api_version="3.4",
     )

--- a/paradime/cli/utils.py
+++ b/paradime/cli/utils.py
@@ -11,7 +11,7 @@ def env_click_option(option_name: str, env_var: Optional[str], **kwargs: Any) ->
     return click.option(
         f"--{option_name}",
         prompt=False,
-        default=None,
+        default=kwargs.pop("default", None),
         envvar=env_var,
         required=kwargs.pop("required", True),
         help=help,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "paradime-io"
-version = "4.10.0"
+version = "4.10.2"
 description = "Paradime - Python SDK"
 authors = ["Bhuvan Singla <bhuvan@paradime.io>", "Maximilian Mitchell <max@paradime.io>"]
 readme = "README.md"


### PR DESCRIPTION
For Tableau sites using the default site, the API requires the site name to be empty. 