### PR TITLE
Add catalog refresh support

### DIFF
--- a/examples/catalog/catalog_refresh.py
+++ b/examples/catalog/catalog_refresh.py
@@ -1,0 +1,8 @@
+# First party modules
+from paradime import Paradime
+
+# Create a Paradime client with your API credentials
+paradime = Paradime(api_endpoint="API_ENDPOINT", api_key="API_KEY", api_secret="API_SECRET")
+
+# Trigger a background refresh of the Paradime catalog
+paradime.catalog.refresh()

--- a/paradime/apis/catalog/client.py
+++ b/paradime/apis/catalog/client.py
@@ -1,0 +1,21 @@
+from paradime.client.api_client import APIClient
+
+
+class CatalogClient:
+    def __init__(self, client: APIClient):
+        self.client = client
+
+    def refresh(self) -> None:
+        """
+        Triggers a background refresh of the Paradime catalog.
+        """
+
+        query = """
+            mutation refreshCatalog {
+                refreshCatalog {
+                    ok
+                }
+            }
+        """
+
+        self.client._call_gql(query)

--- a/paradime/cli/catalog.py
+++ b/paradime/cli/catalog.py
@@ -1,0 +1,30 @@
+import click
+
+from paradime.cli.rich_text_output import print_success
+from paradime.client.paradime_cli_client import get_cli_client_or_exit
+
+
+@click.group()
+def catalog() -> None:
+    """
+    Work with Paradime Catalog from the CLI.
+    """
+    pass
+
+
+@click.command()
+def refresh() -> None:
+    """
+    Trigger a catalog refresh.
+    """
+
+    client = get_cli_client_or_exit()
+    client.catalog.refresh()
+
+    print_success(
+        "The catalog refresh has been triggered successfully. It may take a few minutes to complete.",
+        is_json=False,
+    )
+
+
+catalog.add_command(refresh)

--- a/paradime/cli/cli.py
+++ b/paradime/cli/cli.py
@@ -2,6 +2,7 @@ import click
 from dotenv import load_dotenv
 
 from paradime.cli.bolt import bolt
+from paradime.cli.catalog import catalog
 from paradime.cli.login import login
 from paradime.cli.run import run
 from paradime.cli.version import version
@@ -19,6 +20,7 @@ def cli() -> None:
 
 
 cli.add_command(bolt)
+cli.add_command(catalog)
 cli.add_command(version)
 cli.add_command(login)
 cli.add_command(run)

--- a/paradime/client/paradime_client.py
+++ b/paradime/client/paradime_client.py
@@ -1,5 +1,6 @@
 from paradime.apis.audit_log.client import AuditLogClient
 from paradime.apis.bolt.client import BoltClient
+from paradime.apis.catalog.client import CatalogClient
 from paradime.apis.custom_integration.client import CustomIntegrationClient
 from paradime.apis.lineage_diff.client import LineageDiffClient
 from paradime.apis.users.client import UsersClient
@@ -14,6 +15,7 @@ class Paradime(APIClient):
     Attributes:
         audit_log (AuditLogClient): The audit log API client.
         bolt (BoltClient): The bolt API client.
+        catalog (CatalogClient): The catalog API client.
         custom_integration (CustomIntegrationClient): The custom integration API client.
         lineage_diff (LineageDiffClient): The lineage diff API client.
         users (UsersClient): The users API client.
@@ -27,6 +29,7 @@ class Paradime(APIClient):
 
     audit_log: AuditLogClient
     bolt: BoltClient
+    catalog: CatalogClient
     custom_integration: CustomIntegrationClient
     lineage_diff: LineageDiffClient
     users: UsersClient
@@ -37,6 +40,7 @@ class Paradime(APIClient):
 
         self.audit_log = AuditLogClient(client=self)
         self.bolt = BoltClient(client=self)
+        self.catalog = CatalogClient(client=self)
         self.custom_integration = CustomIntegrationClient(client=self)
         self.lineage_diff = LineageDiffClient(client=self)
         self.users = UsersClient(client=self)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "paradime-io"
-version = "4.10.3"
+version = "4.11.0"
 description = "Paradime - Python SDK"
 authors = ["Bhuvan Singla <bhuvan@paradime.io>", "Maximilian Mitchell <max@paradime.io>"]
 readme = "README.md"


### PR DESCRIPTION
- Adds support for triggering catalog refreshes via both the Python SDK and CLI.
- Bumped version to `4.11.0`


### Python SDK Usage
```py
from paradime import Paradime

client = Paradime(api_endpoint="...", api_key="...", api_secret="...")
client.catalog.refresh()
```

### CLI Usage
```sh
paradime catalog refresh
```
