### PR TITLE
Add support for listing runs of a Bolt schedule

### DIFF
--- a/examples/bolt/list_runs.py
+++ b/examples/bolt/list_runs.py
@@ -1,0 +1,11 @@
+# First party modules
+from paradime import Paradime
+
+# Create a Paradime client with your API credentials
+paradime = Paradime(api_endpoint="API_ENDPOINT", api_key="API_KEY", api_secret="API_SECRET")
+
+# Define the schedule name for which to list runs
+SCHEDULE_NAME = "daily_run"
+
+# List all runs
+runs = paradime.bolt.list_runs(schedule_name=SCHEDULE_NAME).runs

--- a/paradime/apis/bolt/types.py
+++ b/paradime/apis/bolt/types.py
@@ -75,3 +75,25 @@ class BoltCommand(BaseModel):
 class BoltCommandArtifact(BaseModel):
     id: int
     path: str
+
+
+class BoltRunGitInfo(BaseModel):
+    branch: Optional[str]
+    commit_hash: Optional[str]
+    pull_request_id: Optional[str]
+
+
+class BoltRun(BaseModel):
+    id: int
+    state: str
+    actor: str
+    actor_email: Optional[str]
+    parent_schedule_run_id: Optional[int]
+    start_dttm: str
+    end_dttm: Optional[str]
+    git_info: BoltRunGitInfo
+
+
+class BoltScheduleRuns(BaseModel):
+    ok: bool
+    runs: List[BoltRun]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "paradime-io"
-version = "4.15.0"
+version = "4.16.0"
 description = "Paradime - Python SDK"
 authors = ["Bhuvan Singla <bhuvan@paradime.io>", "Maximilian Mitchell <max@paradime.io>"]
 readme = "README.md"


### PR DESCRIPTION
Adds `list_runs()` method to retrieve paginated run history for Bolt schedules.