### PR TITLE
Add TABLEAU_REFRESH_WAIT env var for --wait/--no-wait flag

### DIFF
--- a/paradime/cli/integrations/tableau.py
+++ b/paradime/cli/integrations/tableau.py
@@ -62,7 +62,8 @@ from paradime.core.scripts.tableau import (
 @click.option(
     "--wait/--no-wait",
     default=True,
-    help="Wait for the refresh job to complete before returning. Shows progress and final status.",
+    envvar="TABLEAU_REFRESH_WAIT",
+    help="Wait for the refresh job to complete before returning. Shows progress and final status.\n\n [env: TABLEAU_REFRESH_WAIT]",
 )
 @env_click_option(
     "timeout",


### PR DESCRIPTION
## Summary
- Adds `TABLEAU_REFRESH_WAIT` env var support to the `--wait/--no-wait` flag on `tableau refresh`
- Default remains `true` (wait for completion) — no behaviour change for existing users
- Set `TABLEAU_REFRESH_WAIT=false` to fire-and-forget refreshes without polling

## Test plan
- [ ] Run `tableau refresh` with no env var set — should wait by default
- [ ] Run with `TABLEAU_REFRESH_WAIT=false` — should fire and return immediately (same as `--no-wait`)
- [ ] Run with `--no-wait` flag explicitly — should still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)