### PR TITLE
Add bolt retry support to SDK and CLI

### DIFF
--- a/examples/bolt/retry_run.py
+++ b/examples/bolt/retry_run.py
@@ -1,0 +1,16 @@
+# First party modules
+from paradime import Paradime
+
+# Create a Paradime client with your API credentials
+paradime = Paradime(api_endpoint="API_ENDPOINT", api_key="API_KEY", api_secret="API_SECRET")
+
+BOLT_SCHEDULE_RUN_ID = 1  # Replace with the run ID of the failed Bolt schedule to retry
+
+# Retry only the failed commands from a previous Bolt run.
+# Uses `dbt retry` under the hood when the failed command supports it.
+new_run_id = paradime.bolt.retry_run(BOLT_SCHEDULE_RUN_ID)
+print(f"Retry (failed only) started: run_id={new_run_id}")
+
+# Or retry every original command verbatim, regardless of status.
+new_run_id_all = paradime.bolt.retry_run_all(BOLT_SCHEDULE_RUN_ID)
+print(f"Retry (all commands) started: run_id={new_run_id_all}")

--- a/paradime/apis/bolt/client.py
+++ b/paradime/apis/bolt/client.py
@@ -517,6 +517,63 @@ class BoltClient:
 
         self.client._call_gql(query=query, variables={"runId": int(run_id)})
 
+    def retry_run(self, run_id: int) -> int:
+        """
+        Retries a failed Bolt run by re-running only the failed commands.
+
+        The first failed dbt command is substituted with `dbt retry` when supported,
+        re-running just the failed models. Infrastructure commands (git clone, dbt deps)
+        are skipped.
+
+        Args:
+            run_id (int): The ID of the failed run to retry.
+
+        Returns:
+            int: The ID of the newly created retry run.
+        """
+
+        query = """
+            mutation RetryBoltRun($scheduleRunId: Int!) {
+                retryBoltRun(scheduleRunId: $scheduleRunId) {
+                    runId
+                }
+            }
+        """
+
+        response_json = self.client._call_gql(
+            query=query, variables={"scheduleRunId": int(run_id)}
+        )["retryBoltRun"]
+
+        return response_json["runId"]
+
+    def retry_run_all(self, run_id: int) -> int:
+        """
+        Retries a Bolt run by re-running ALL original commands.
+
+        Every command from the original run is re-executed verbatim, except
+        infrastructure commands (git clone, dbt deps).
+
+        Args:
+            run_id (int): The ID of the run to retry.
+
+        Returns:
+            int: The ID of the newly created retry run.
+        """
+
+        query = """
+            mutation RetryAllBoltRun($scheduleRunId: Int!) {
+                retryAllBoltRun(scheduleRunId: $scheduleRunId) {
+                    runId
+                }
+            }
+        """
+
+        response_json = self.client._call_gql(
+            query=query, variables={"scheduleRunId": int(run_id)}
+        )["retryAllBoltRun"]
+
+        return response_json["runId"]
+
     def get_latest_artifact_url(
         self,
         *,

--- a/paradime/cli/bolt.py
+++ b/paradime/cli/bolt.py
@@ -126,6 +126,50 @@ def run(
 
 @click.command()
 @click.option(
+    "--all",
+    "retry_all",
+    is_flag=True,
+    help="Retry ALL commands from the original run (default: failed commands only).",
+)
+@click.option("--wait", help="Wait for the retry run to finish", is_flag=True)
+@click.option("--json", help="JSON formatted response", is_flag=True)
+@click.argument("run_id", type=int)
+def retry(retry_all: bool, wait: bool, json: bool, run_id: int) -> None:
+    """
+    Retry a failed Paradime Bolt run.
+    """
+    if not json:
+        print_version()
+
+    client = get_cli_client_or_exit()
+    try:
+        new_run_id = (
+            client.bolt.retry_run_all(run_id) if retry_all else client.bolt.retry_run(run_id)
+        )
+    except ParadimeAPIException as e:
+        print_error_table(f"Failed to retry run: {e}", is_json=json)
+        sys.exit(1)
+
+    print_run_started(new_run_id, json)
+
+    if wait:
+        while True:
+            status = client.bolt.get_run_status(new_run_id)
+            if not status:
+                print_error_table("Unable to fetch status from bolt.", is_json=json)
+                sys.exit(1)
+
+            print_run_status(status.value, json)
+            if status is not BoltRunState.RUNNING:
+                break
+            time.sleep(WAIT_SLEEP)
+
+        if status is not BoltRunState.SUCCESS:
+            sys.exit(1)
+
+
+@click.command()
+@click.option(
     "--path",
     help="Path to paradime_schedules.yml file.",
     show_default=True,
@@ -211,6 +255,7 @@ def bolt() -> None:
 
 # bolt
 bolt.add_command(run)
+bolt.add_command(retry)
 bolt.add_command(schedule)
 bolt.add_command(verify)
 bolt.add_command(artifact)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "paradime-io"
-version = "5.3.0"
+version = "5.4.0"
 description = "Paradime - Python SDK"
 authors = [
     { name = "Bhuvan Singla", email = "bhuvan@paradime.io" },

--- a/uv.lock
+++ b/uv.lock
@@ -916,7 +916,7 @@ wheels = [
 
 [[package]]
 name = "paradime-io"
-version = "5.3.0"
+version = "5.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## Summary
- Adds `paradime.bolt.retry_run(run_id)` and `paradime.bolt.retry_run_all(run_id)` wrapping the new `retryBoltRun` / `retryAllBoltRun` public-API mutations from [paradime-backend#3492](https://github.com/paradime-io/paradime-backend/pull/3492). Both return the new retry run's id.
- Adds `paradime bolt retry <run_id> [--all] [--wait] [--json]` CLI command. `--all` re-runs every original command; without it only failed commands are retried (using `dbt retry` when supported). `--wait` polls the new run id until terminal, exiting non-zero on failure — same pattern as `paradime bolt run --wait`.
- Adds `examples/bolt/retry_run.py` demonstrating both retry modes.

Backend user-facing errors (`ScheduleRunNotFailedException`, `NoCommandsToRetryException`, etc.) surface as `ParadimeAPIException` via the existing `_call_gql` error path — no new exception types needed.

## SDK usage

```python
from paradime import Paradime

paradime = Paradime(
    api_endpoint="API_ENDPOINT",
    api_key="API_KEY",
    api_secret="API_SECRET",
)

FAILED_RUN_ID = 123

# Retry only the failed commands from a previous Bolt run.
# Uses `dbt retry` under the hood when the failed command supports it.
new_run_id = paradime.bolt.retry_run(run_id=FAILED_RUN_ID)
print(f"Retry (failed only) started: run_id={new_run_id}")

# Or retry every original command verbatim (excluding git clone / dbt deps).
new_run_id_all = paradime.bolt.retry_run_all(run_id=FAILED_RUN_ID)
print(f"Retry (all commands) started: run_id={new_run_id_all}")

# Both return the NEW run id — poll it like any other run.
status = paradime.bolt.get_run_status(new_run_id)
print(status)  # BoltRunState.STARTING / RUNNING / SUCCESS / ...
```

## CLI usage

```bash
# Retry only the failed commands from run 123
paradime bolt retry 123

# Retry ALL commands from run 123
paradime bolt retry 123 --all

# Retry and block until the new run reaches a terminal state;
# exits non-zero if the retry doesn't succeed (CI-friendly)
paradime bolt retry 123 --wait

# JSON output (no banner / styled boxes)
paradime bolt retry 123 --wait --json
```

`paradime bolt retry --help`:

```
Usage: paradime bolt retry [OPTIONS] RUN_ID

  Retry a failed Paradime Bolt run.

Options:
  --all   Retry ALL commands from the original run (default: failed commands
          only).
  --wait  Wait for the retry run to finish
  --json  JSON formatted response
  --help  Show this message and exit.
```

## Test plan
- [x] `poetry run black` / `isort` / `flake8` clean on changed files
- [x] `BoltClient.retry_run` and `retry_run_all` import and expose docstrings
- [x] `paradime bolt retry --help` renders correctly and is registered on the bolt group
- [ ] Smoke test against a real failed run id: `paradime.bolt.retry_run(<failed_run_id>)` returns a new int run id, pollable via `get_run_status`
- [ ] CLI smoke: `paradime bolt retry <id>`, `--all`, `--wait` against a dev workspace
- [ ] Error path: retrying a successful run surfaces backend "All commands were successful, nothing to retry" as `ParadimeAPIException`

🤖 Generated with [Claude Code](https://claude.com/claude-code)