### PR TITLE
Fix DinoAI Agents SDK slack override GraphQL field name

### DIFF
--- a/paradime/apis/dinoai_agents/client.py
+++ b/paradime/apis/dinoai_agents/client.py
@@ -64,11 +64,9 @@ class DinoaiAgentsClient:
 
         slack: Optional[dict] = None
         if slack_channel is not None or slack_thread is not None:
-            slack = {}
-            if slack_channel is not None:
-                slack["channel"] = slack_channel
-            if slack_thread is not None:
-                slack["thread"] = slack_thread
+            if slack_channel is None or slack_thread is None:
+                raise ValueError("slack_channel and slack_thread must be provided together")
+            slack = {"channel": slack_channel, "threadTs": slack_thread}
 
         variables = {
             "agent": agent,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "paradime-io"
-version = "5.5.0"
+version = "5.6.0"
 description = "Paradime - Python SDK"
 authors = [
     { name = "Bhuvan Singla", email = "bhuvan@paradime.io" },

--- a/uv.lock
+++ b/uv.lock
@@ -916,7 +916,7 @@ wheels = [
 
 [[package]]
 name = "paradime-io"
-version = "5.5.0"
+version = "5.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## Summary
- Fix `DinoaiAgentsClient.trigger_run` to send `slack.threadTs` (matching the `DinoAiAgentSlackInput` schema) instead of `slack.thread`, which caused server-side GraphQL validation errors for any caller passing `slack_thread=`.
- Enforce that `slack_channel` and `slack_thread` are provided together with a clear `ValueError`, since both fields are `NonNull` on the server.

Closes [ENG-2925](https://linear.app/building-paradime/issue/ENG-2925/fix-dinoai-agents-sdk-slack-override-sends-wrong-graphql-field-name).

## Test plan
- [x] `trigger_run(slack_channel=...)` alone raises `ValueError`
- [x] `trigger_run(slack_thread=...)` alone raises `ValueError`
- [x] `trigger_run(slack_channel="C0B3DFPQK7W", slack_thread="...")` returns `ok=True` end-to-end (server accepts `threadTs`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)