### PR TITLE
Add runtime telemetry headers (Python version + execution environment)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,14 @@ export PARADIME_API_SECRET="YOUR_API_SECRET
 ## Examples
 
 Find usage examples [here](https://github.com/paradime-io/paradime-python-sdk/tree/main/examples) to get started with the Paradime Python SDK.
+
+## Telemetry
+
+Each API call sends `X-PYTHON-VERSION` (e.g. `3.11.5`) and `X-PARADIME-RUNTIME` (e.g. `github-actions`, `airflow`, `paradime-bolt`, `local`) to help Paradime understand how the SDK is being used. Only the *presence* of well-known CI/platform environment variables is checked — no values are ever transmitted.
+
+To opt out:
+
+```bash
+export PARADIME_DISABLE_TELEMETRY=true
+```
+

--- a/paradime/client/api_client.py
+++ b/paradime/client/api_client.py
@@ -3,11 +3,7 @@ from typing import Any, Dict
 import requests
 
 from paradime.client.api_exception import ParadimeAPIException
-from paradime.client.runtime import (
-    detect_runtime,
-    get_python_version,
-    is_telemetry_enabled,
-)
+from paradime.client.runtime import detect_runtime, get_python_version, is_telemetry_enabled
 from paradime.version import get_sdk_version
 
 

--- a/paradime/client/api_client.py
+++ b/paradime/client/api_client.py
@@ -3,6 +3,11 @@ from typing import Any, Dict
 import requests
 
 from paradime.client.api_exception import ParadimeAPIException
+from paradime.client.runtime import (
+    detect_runtime,
+    get_python_version,
+    is_telemetry_enabled,
+)
 from paradime.version import get_sdk_version
 
 
@@ -38,12 +43,18 @@ class APIClient:
             dict: The request headers.
         """
 
-        return {
+        headers: Dict[str, str] = {
             "Content-Type": "application/json",
             "X-API-KEY": self.api_key,
             "X-API-SECRET": self.api_secret,
             "X-PYTHON-SDK-VERSION": get_sdk_version(),
         }
+
+        if is_telemetry_enabled():
+            headers["X-PYTHON-VERSION"] = get_python_version()
+            headers["X-PARADIME-RUNTIME"] = detect_runtime()
+
+        return headers
 
     def _raise_for_gql_response_body_errors(self, response: requests.Response) -> None:
         """
@@ -81,7 +92,9 @@ class APIClient:
         try:
             response.raise_for_status()
         except Exception as e:
-            raise ParadimeAPIException(f"Error: {response.status_code} - {response.text}") from e
+            raise ParadimeAPIException(
+                f"Error: {response.status_code} - {response.text}"
+            ) from e
 
     def _raise_for_errors(self, response: requests.Response) -> None:
         """

--- a/paradime/client/api_client.py
+++ b/paradime/client/api_client.py
@@ -92,9 +92,7 @@ class APIClient:
         try:
             response.raise_for_status()
         except Exception as e:
-            raise ParadimeAPIException(
-                f"Error: {response.status_code} - {response.text}"
-            ) from e
+            raise ParadimeAPIException(f"Error: {response.status_code} - {response.text}") from e
 
     def _raise_for_errors(self, response: requests.Response) -> None:
         """

--- a/paradime/client/runtime.py
+++ b/paradime/client/runtime.py
@@ -1,0 +1,80 @@
+import os
+import sys
+from pathlib import Path
+
+DISABLE_TELEMETRY_ENV_VAR = "PARADIME_DISABLE_TELEMETRY"
+
+
+def is_telemetry_enabled() -> bool:
+    """Return False if the user has opted out via PARADIME_DISABLE_TELEMETRY=true."""
+    return os.environ.get(DISABLE_TELEMETRY_ENV_VAR, "").lower() not in (
+        "true",
+        "1",
+        "yes",
+    )
+
+
+def get_python_version() -> str:
+    """Return the current Python version as a string, e.g. '3.11.5'."""
+    v = sys.version_info
+    return f"{v.major}.{v.minor}.{v.micro}"
+
+
+def detect_runtime() -> str:
+    """
+    Detect the execution environment by inspecting well-known environment variables.
+
+    Returns a short slug sent as the X-PARADIME-RUNTIME header. Only environment
+    variable *presence* is checked — no values are ever read or transmitted.
+
+    Returns 'unknown' if detection fails for any reason.
+    """
+
+    try:
+        # ── Paradime Bolt (checked first — most specific) ──────────────────────
+        if os.environ.get("PARADIME_SCHEDULE_NAME"):
+            return "paradime-bolt"
+
+        # ── CI / CD platforms ──────────────────────────────────────────────────
+        if os.environ.get("GITHUB_ACTIONS") == "true":
+            return "github-actions"
+        if os.environ.get("GITLAB_CI") == "true":
+            return "gitlab-ci"
+        if os.environ.get("CIRCLECI") == "true":
+            return "circleci"
+        if os.environ.get("JENKINS_URL"):
+            return "jenkins"
+        if os.environ.get("BITBUCKET_BUILD_NUMBER"):
+            return "bitbucket-pipelines"
+        if os.environ.get("TF_BUILD"):  # Azure DevOps
+            return "azure-devops"
+
+        # ── Workflow orchestrators ─────────────────────────────────────────────
+        if os.environ.get("AIRFLOW_CTX_DAG_ID") or os.environ.get("AIRFLOW_HOME"):
+            return "airflow"
+        if os.environ.get("PREFECT__CONTEXT__FLOW_RUN_ID"):
+            return "prefect"
+        if os.environ.get("DAGSTER_HOME") or os.environ.get("DAGSTER_PID"):
+            return "dagster"
+
+        # ── Serverless / cloud functions ───────────────────────────────────────
+        if os.environ.get("AWS_LAMBDA_FUNCTION_NAME"):
+            return "aws-lambda"
+        if os.environ.get("K_SERVICE") or os.environ.get("FUNCTION_TARGET"):
+            return "gcp-cloud"
+        if os.environ.get("FUNCTIONS_WORKER_RUNTIME"):
+            return "azure-functions"
+
+        # ── Container / cluster ────────────────────────────────────────────────
+        if os.environ.get("KUBERNETES_SERVICE_HOST"):
+            return "kubernetes"
+        try:
+            if Path("/.dockerenv").exists():
+                return "docker"
+        except OSError:
+            pass
+
+        return "local"
+
+    except Exception:
+        return "unknown"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "paradime-io"
-version = "5.5.0"
+version = "5.6.0"
 description = "Paradime - Python SDK"
 authors = [
     { name = "Bhuvan Singla", email = "bhuvan@paradime.io" },

--- a/uv.lock
+++ b/uv.lock
@@ -916,7 +916,7 @@ wheels = [
 
 [[package]]
 name = "paradime-io"
-version = "5.5.0"
+version = "5.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## What

Adds two new opt-out headers sent on every API request to help the backend track how the SDK is being used:

| Header | Example | Notes |
|---|---|---|
| `X-PYTHON-VERSION` | `3.11.5` | Python interpreter version |
| `X-PARADIME-RUNTIME` | `paradime-bolt`, `github-actions`, `airflow`, `local` | Detected via well-known env vars |

## How

New `paradime/client/runtime.py` module:
- **Bolt** detected via `PARADIME_SCHEDULE_NAME` (injected by the scheduler into every dbt run)
- **CI platforms**: `GITHUB_ACTIONS`, `GITLAB_CI`, `CIRCLECI`, `JENKINS_URL`, etc.
- **Orchestrators**: `AIRFLOW_CTX_DAG_ID`, `PREFECT__CONTEXT__FLOW_RUN_ID`, `DAGSTER_HOME`
- **Serverless**: `AWS_LAMBDA_FUNCTION_NAME`, `K_SERVICE`, `FUNCTIONS_WORKER_RUNTIME`
- **Containers**: `KUBERNETES_SERVICE_HOST`, `/.dockerenv` (checked safely with `OSError` guard)
- Only env var *presence* is checked — no values are ever transmitted
- Entire detection wrapped in `try/except` — returns `'unknown'` on any failure

## Opt-out

```bash
export PARADIME_DISABLE_TELEMETRY=true
```

Suppresses `X-PYTHON-VERSION` and `X-PARADIME-RUNTIME`. `X-PYTHON-SDK-VERSION` is always sent (functional, not telemetry).

## Version bump

`5.5.0` → `5.6.0`