### PR TITLE
ENG-3104 feat(bolt): auto-mint schedule slugs in verify command

### DIFF
--- a/paradime/apis/bolt/client.py
+++ b/paradime/apis/bolt/client.py
@@ -925,3 +925,26 @@ class BoltClient:
 
         # Default to False for unknown commands
         return False
+
+    def mint_schedule_slugs(self, display_names: List[str]) -> List[str]:
+        """Mint slugs for a list of display names via the backend.
+
+        Args:
+            display_names: Human-readable schedule names to mint slugs for.
+
+        Returns:
+            List of minted slugs in the same order as the input display names.
+        """
+        query = """
+            mutation mintScheduleSlugs($displayNames: [String!]!) {
+                mintScheduleSlugs(displayNames: $displayNames) {
+                    ok
+                    slugs
+                }
+            }
+        """
+        response = self.client._call_gql(
+            query=query,
+            variables={"displayNames": display_names},
+        )["mintScheduleSlugs"]
+        return response["slugs"]

--- a/paradime/apis/bolt/client.py
+++ b/paradime/apis/bolt/client.py
@@ -926,7 +926,7 @@ class BoltClient:
         # Default to False for unknown commands
         return False
 
-    def mint_schedule_slugs(self, display_names: List[str]) -> List[str]:
+    def create_schedule_slugs(self, display_names: List[str]) -> List[str]:
         """Mint slugs for a list of display names via the backend.
 
         Args:
@@ -936,8 +936,8 @@ class BoltClient:
             List of minted slugs in the same order as the input display names.
         """
         query = """
-            mutation mintScheduleSlugs($displayNames: [String!]!) {
-                mintScheduleSlugs(displayNames: $displayNames) {
+            mutation createScheduleSlugs($displayNames: [String!]!) {
+                createScheduleSlugs(displayNames: $displayNames) {
                     ok
                     slugs
                 }
@@ -946,5 +946,5 @@ class BoltClient:
         response = self.client._call_gql(
             query=query,
             variables={"displayNames": display_names},
-        )["mintScheduleSlugs"]
+        )["createScheduleSlugs"]
         return response["slugs"]

--- a/paradime/cli/bolt.py
+++ b/paradime/cli/bolt.py
@@ -18,7 +18,12 @@ from paradime.cli.rich_text_output import (
 from paradime.cli.version import print_version
 from paradime.client.api_exception import ParadimeAPIException, ParadimeException
 from paradime.client.paradime_cli_client import get_cli_client_or_exit
-from paradime.core.bolt.schedule import SCHEDULE_FILE_NAME, is_valid_schedule_at_path
+from paradime.core.bolt.schedule import (
+    SCHEDULE_FILE_NAME,
+    _get_schedules,
+    get_slug_format_warnings,
+    is_valid_schedule_at_path,
+)
 
 WAIT_SLEEP: Final = 10
 
@@ -217,10 +222,21 @@ def verify(path: str) -> None:
     Verify the paradime_schedules.yml file.
     """
     print_version()
-    error_string = is_valid_schedule_at_path(Path(path))
+    schedule_path = Path(path)
+    error_string = is_valid_schedule_at_path(schedule_path)
     if error_string:
         print_error_table(error_string, is_json=False)
         sys.exit(1)
+
+    # Non-blocking slug-format nudges. New schedules should use slug-format
+    # names; existing non-slug names continue to deploy via backend grandfathering.
+    try:
+        schedules = _get_schedules(schedule_path)
+    except Exception:
+        schedules = None
+    if schedules:
+        for warning in get_slug_format_warnings(schedules):
+            click.secho(f"warning: {warning}", fg="yellow")
 
 
 @click.command()

--- a/paradime/cli/bolt.py
+++ b/paradime/cli/bolt.py
@@ -217,7 +217,7 @@ def retry(retry_all: bool, wait: bool, json: bool, run_id: int) -> None:
     "--path",
     help="Path to paradime_schedules.yml file or project root containing .bolt/ directory.",
     show_default=True,
-    default=SCHEDULE_FILE_NAME,
+    default=".",
 )
 def verify(path: str) -> None:
     """

--- a/paradime/cli/bolt.py
+++ b/paradime/cli/bolt.py
@@ -19,11 +19,9 @@ from paradime.cli.version import print_version
 from paradime.client.api_exception import ParadimeAPIException, ParadimeException
 from paradime.client.paradime_cli_client import get_cli_client_or_exit
 from paradime.core.bolt.schedule import (
-    SCHEDULE_FILE_NAME,
     _get_schedules,
     get_slug_format_warnings,
     is_valid_schedule_at_path,
-    is_valid_slug,
 )
 from paradime.core.bolt.yaml_rewriter import mint_slugs_in_yaml_files
 
@@ -241,21 +239,18 @@ def verify(path: str) -> None:
         print_error_table(error_string, is_json=False)
         sys.exit(1)
 
-    # Check for non-slug names and mint slugs via the backend
+    # Check for names not yet registered in the backend and mint slugs.
     try:
         schedules = _get_schedules(schedule_path)
     except Exception:
         schedules = None
 
-    has_non_slugs = schedules and any(not is_valid_slug(s.name) for s in schedules.schedules)
-
-    if has_non_slugs:
+    if schedules:
         try:
             client = get_cli_client_or_exit()
             root = schedule_path.parent if schedule_path.is_file() else schedule_path
 
-            # Fetch existing schedule names from the backend so we don't
-            # rewrite names that are already deployed (grandfathered).
+            # Fetch existing schedule names from the backend.
             existing_names: set[str] = set()
             try:
                 all_schedules = client.bolt.list_schedules(offset=0, limit=10000)
@@ -263,13 +258,22 @@ def verify(path: str) -> None:
             except Exception:
                 pass  # If we can't fetch, we'll mint everything
 
-            changed = mint_slugs_in_yaml_files(
-                mint_fn=client.bolt.create_schedule_slugs,
-                root=root,
-                existing_names=existing_names,
+            has_unregistered = any(
+                s.name not in existing_names for s in schedules.schedules
             )
-            if changed:
-                click.secho(f"Minted slugs in {changed} file(s).", fg="green")
+
+            if has_unregistered:
+                changed = mint_slugs_in_yaml_files(
+                    mint_fn=client.bolt.create_schedule_slugs,
+                    root=root,
+                    existing_names=existing_names,
+                )
+                if changed:
+                    click.secho(f"Minted slugs in {changed} file(s).", fg="green")
+                else:
+                    click.secho("All schedules verified.", fg="green")
+            else:
+                click.secho("All schedules verified.", fg="green")
         except (ParadimeAPIException, ParadimeException) as e:
             click.secho(
                 f"Could not mint slugs (API unavailable): {e}\n"

--- a/paradime/cli/bolt.py
+++ b/paradime/cli/bolt.py
@@ -264,7 +264,7 @@ def verify(path: str) -> None:
                 pass  # If we can't fetch, we'll mint everything
 
             changed = mint_slugs_in_yaml_files(
-                mint_fn=client.bolt.mint_schedule_slugs,
+                mint_fn=client.bolt.create_schedule_slugs,
                 root=root,
                 existing_names=existing_names,
             )

--- a/paradime/cli/bolt.py
+++ b/paradime/cli/bolt.py
@@ -245,48 +245,58 @@ def verify(path: str) -> None:
     except Exception:
         schedules = None
 
-    if schedules:
+    if not schedules:
+        click.secho("No schedules found.", fg="yellow")
+        return
+
+    click.secho(
+        f"Found {len(schedules.schedules)} schedule(s): "
+        + ", ".join(s.name for s in schedules.schedules),
+        fg="cyan",
+    )
+
+    try:
+        client = get_cli_client_or_exit()
+        root = schedule_path.parent if schedule_path.is_file() else schedule_path
+
+        # Fetch existing schedule names from the backend.
+        existing_names: set[str] = set()
         try:
-            client = get_cli_client_or_exit()
-            root = schedule_path.parent if schedule_path.is_file() else schedule_path
+            all_schedules = client.bolt.list_schedules(offset=0, limit=10000)
+            existing_names = {s.name for s in all_schedules.schedules}
+            click.secho(f"Backend has {len(existing_names)} existing schedule(s).", fg="cyan")
+        except Exception:
+            click.secho("Could not fetch existing schedules — will mint all.", fg="yellow")
 
-            # Fetch existing schedule names from the backend.
-            existing_names: set[str] = set()
-            try:
-                all_schedules = client.bolt.list_schedules(offset=0, limit=10000)
-                existing_names = {s.name for s in all_schedules.schedules}
-            except Exception:
-                pass  # If we can't fetch, we'll mint everything
+        unregistered = [s.name for s in schedules.schedules if s.name not in existing_names]
 
-            has_unregistered = any(
-                s.name not in existing_names for s in schedules.schedules
-            )
-
-            if has_unregistered:
-                changed = mint_slugs_in_yaml_files(
-                    mint_fn=client.bolt.create_schedule_slugs,
-                    root=root,
-                    existing_names=existing_names,
-                )
-                if changed:
-                    click.secho(f"Minted slugs in {changed} file(s).", fg="green")
-                else:
-                    click.secho("All schedules verified.", fg="green")
-            else:
-                click.secho("All schedules verified.", fg="green")
-        except (ParadimeAPIException, ParadimeException) as e:
+        if unregistered:
             click.secho(
-                f"Could not mint slugs (API unavailable): {e}\n"
-                f"Non-slug schedule names will be grandfathered by the backend on deploy.",
+                f"Unregistered schedule(s) needing slugs: {', '.join(unregistered)}",
                 fg="yellow",
             )
-        except Exception:
-            # Fall back to warnings if minting fails for any reason
-            if schedules:
-                for warning in get_slug_format_warnings(schedules):
-                    click.secho(f"warning: {warning}", fg="yellow")
-    else:
-        click.secho("All schedules verified.", fg="green")
+            changed = mint_slugs_in_yaml_files(
+                mint_fn=client.bolt.create_schedule_slugs,
+                root=root,
+                existing_names=existing_names,
+            )
+            if changed:
+                click.secho(f"Minted slugs in {changed} file(s).", fg="green")
+            else:
+                click.secho("All schedules verified.", fg="green")
+        else:
+            click.secho("All schedules verified.", fg="green")
+    except (ParadimeAPIException, ParadimeException) as e:
+        click.secho(
+            f"Could not mint slugs (API unavailable): {e}\n"
+            f"Non-slug schedule names will be grandfathered by the backend on deploy.",
+            fg="yellow",
+        )
+    except Exception:
+        # Fall back to warnings if minting fails for any reason
+        if schedules:
+            for warning in get_slug_format_warnings(schedules):
+                click.secho(f"warning: {warning}", fg="yellow")
 
 
 @click.command()

--- a/paradime/cli/bolt.py
+++ b/paradime/cli/bolt.py
@@ -234,7 +234,21 @@ def verify(path: str) -> None:
     """
     print_version()
     schedule_path = Path(path)
-    error_string = is_valid_schedule_at_path(schedule_path)
+
+    # Fetch existing schedule names from the backend early so we can use
+    # them for both validation and slug minting.
+    existing_names: set[str] = set()
+    try:
+        client = get_cli_client_or_exit()
+        try:
+            all_schedules = client.bolt.list_schedules(offset=0, limit=10000)
+            existing_names = {s.name for s in all_schedules.schedules}
+        except Exception:
+            pass
+    except (ParadimeAPIException, ParadimeException):
+        client = None
+
+    error_string = is_valid_schedule_at_path(schedule_path, existing_names=existing_names)
     if error_string:
         print_error_table(error_string, is_json=False)
         sys.exit(1)
@@ -249,32 +263,14 @@ def verify(path: str) -> None:
         click.secho("No schedules found.", fg="yellow")
         return
 
-    click.secho(
-        f"Found {len(schedules.schedules)} schedule(s): "
-        + ", ".join(s.name for s in schedules.schedules),
-        fg="cyan",
-    )
-
     try:
-        client = get_cli_client_or_exit()
+        if not client:
+            client = get_cli_client_or_exit()
         root = schedule_path.parent if schedule_path.is_file() else schedule_path
-
-        # Fetch existing schedule names from the backend.
-        existing_names: set[str] = set()
-        try:
-            all_schedules = client.bolt.list_schedules(offset=0, limit=10000)
-            existing_names = {s.name for s in all_schedules.schedules}
-            click.secho(f"Backend has {len(existing_names)} existing schedule(s).", fg="cyan")
-        except Exception:
-            click.secho("Could not fetch existing schedules — will mint all.", fg="yellow")
 
         unregistered = [s.name for s in schedules.schedules if s.name not in existing_names]
 
         if unregistered:
-            click.secho(
-                f"Unregistered schedule(s) needing slugs: {', '.join(unregistered)}",
-                fg="yellow",
-            )
             changed = mint_slugs_in_yaml_files(
                 mint_fn=client.bolt.create_schedule_slugs,
                 root=root,

--- a/paradime/cli/bolt.py
+++ b/paradime/cli/bolt.py
@@ -23,7 +23,9 @@ from paradime.core.bolt.schedule import (
     _get_schedules,
     get_slug_format_warnings,
     is_valid_schedule_at_path,
+    is_valid_slug,
 )
+from paradime.core.bolt.yaml_rewriter import mint_slugs_in_yaml_files
 
 WAIT_SLEEP: Final = 10
 
@@ -213,13 +215,24 @@ def retry(retry_all: bool, wait: bool, json: bool, run_id: int) -> None:
 @click.command()
 @click.option(
     "--path",
-    help="Path to paradime_schedules.yml file.",
+    help="Path to paradime_schedules.yml file or project root containing .bolt/ directory.",
     show_default=True,
     default=SCHEDULE_FILE_NAME,
 )
 def verify(path: str) -> None:
     """
-    Verify the paradime_schedules.yml file.
+    Verify schedule YAML files and mint slugs for new schedules.
+
+    Validates the schedule configuration, then checks for schedules whose
+    ``name`` is not a valid slug. For those, calls the Paradime backend to
+    mint slugs and rewrites the YAML in place — moving the current ``name``
+    to ``display_name`` and inserting the minted slug as ``name``.
+
+    Also resolves cross-references in ``deferred_schedule``, ``turbo_ci``,
+    and ``schedule_trigger`` sections to use the minted slugs.
+
+    Supports both the flat ``paradime_schedules.yml`` layout and the modular
+    ``.bolt/`` folder layout.
     """
     print_version()
     schedule_path = Path(path)
@@ -228,15 +241,48 @@ def verify(path: str) -> None:
         print_error_table(error_string, is_json=False)
         sys.exit(1)
 
-    # Non-blocking slug-format nudges. New schedules should use slug-format
-    # names; existing non-slug names continue to deploy via backend grandfathering.
+    # Check for non-slug names and mint slugs via the backend
     try:
         schedules = _get_schedules(schedule_path)
     except Exception:
         schedules = None
-    if schedules:
-        for warning in get_slug_format_warnings(schedules):
-            click.secho(f"warning: {warning}", fg="yellow")
+
+    has_non_slugs = schedules and any(not is_valid_slug(s.name) for s in schedules.schedules)
+
+    if has_non_slugs:
+        try:
+            client = get_cli_client_or_exit()
+            root = schedule_path.parent if schedule_path.is_file() else schedule_path
+
+            # Fetch existing schedule names from the backend so we don't
+            # rewrite names that are already deployed (grandfathered).
+            existing_names: set[str] = set()
+            try:
+                all_schedules = client.bolt.list_schedules(offset=0, limit=10000)
+                existing_names = {s.name for s in all_schedules.schedules}
+            except Exception:
+                pass  # If we can't fetch, we'll mint everything
+
+            changed = mint_slugs_in_yaml_files(
+                mint_fn=client.bolt.mint_schedule_slugs,
+                root=root,
+                existing_names=existing_names,
+            )
+            if changed:
+                click.secho(f"Minted slugs in {changed} file(s).", fg="green")
+        except (ParadimeAPIException, ParadimeException) as e:
+            click.secho(
+                f"Could not mint slugs (API unavailable): {e}\n"
+                f"Non-slug schedule names will be grandfathered by the backend on deploy.",
+                fg="yellow",
+            )
+        except Exception:
+            # Fall back to warnings if minting fails for any reason
+            if schedules:
+                for warning in get_slug_format_warnings(schedules):
+                    click.secho(f"warning: {warning}", fg="yellow")
+    else:
+        click.secho("All schedules verified.", fg="green")
 
 
 @click.command()

--- a/paradime/core/bolt/schedule.py
+++ b/paradime/core/bolt/schedule.py
@@ -259,9 +259,7 @@ class ParadimeSchedule(ParadimeScheduleBase):
         if "\n" in display_name or "\r" in display_name:
             raise ValueError("display_name must not contain newlines")
         if len(display_name) > DISPLAY_NAME_MAX_LENGTH:
-            raise ValueError(
-                f"display_name must be {DISPLAY_NAME_MAX_LENGTH} characters or fewer"
-            )
+            raise ValueError(f"display_name must be {DISPLAY_NAME_MAX_LENGTH} characters or fewer")
         return display_name
 
 

--- a/paradime/core/bolt/schedule.py
+++ b/paradime/core/bolt/schedule.py
@@ -279,7 +279,10 @@ def get_slug_format_warnings(schedules: ParadimeSchedules) -> List[str]:
     return warnings
 
 
-def is_valid_schedule_at_path(file_path: Path) -> Optional[str]:
+def is_valid_schedule_at_path(
+    file_path: Path,
+    existing_names: Optional[set] = None,
+) -> Optional[str]:
     try:
         schedules = _get_schedules(file_path)
     except Exception as e:
@@ -293,16 +296,21 @@ def is_valid_schedule_at_path(file_path: Path) -> Optional[str]:
     if len(schedule_names) > len(set(schedule_names)):
         return "Schedule names are not unique."
 
-    # check turbo ci / deferred references resolve to existing schedules
+    # All known names: local YAML + backend (if available)
+    known_names = set(schedule_names)
+    if existing_names:
+        known_names |= existing_names
+
+    # check turbo ci / deferred references resolve to known schedules
     # (multiple turbo CI configs are supported)
     for schedule in schedules.schedules:
         if schedule.turbo_ci and schedule.turbo_ci.enabled:
-            if schedule.turbo_ci.deferred_schedule_name not in schedule_names:
-                return f"Turbo CI schedule error: '{schedule.turbo_ci.deferred_schedule_name}' does not refer to another schedule name"
+            if schedule.turbo_ci.deferred_schedule_name not in known_names:
+                return f"Turbo CI schedule error: '{schedule.turbo_ci.deferred_schedule_name}' does not refer to a known schedule name"
 
         if schedule.deferred_schedule and schedule.deferred_schedule.enabled:
-            if schedule.deferred_schedule.deferred_schedule_name not in schedule_names:
-                return f"Deferred schedule error: '{schedule.deferred_schedule.deferred_schedule_name}' does not refer to another schedule name"
+            if schedule.deferred_schedule.deferred_schedule_name not in known_names:
+                return f"Deferred schedule error: '{schedule.deferred_schedule.deferred_schedule_name}' does not refer to a known schedule name"
 
     # Verify schedules individually
     for schedule in schedules.schedules:
@@ -375,9 +383,7 @@ def _find_schedule_files(path: Path) -> List[Path]:
     bolt_dir = root / SCHEDULES_DIR_NAME
     if bolt_dir.is_dir():
         files.extend(
-            sorted(
-                p for p in bolt_dir.rglob("*") if p.is_file() and p.suffix in (".yaml", ".yml")
-            )
+            sorted(p for p in bolt_dir.rglob("*") if p.is_file() and p.suffix in (".yaml", ".yml"))
         )
 
     # Collect flat file(s)

--- a/paradime/core/bolt/schedule.py
+++ b/paradime/core/bolt/schedule.py
@@ -1,4 +1,8 @@
+import re
+import secrets
 import shlex
+import string
+import unicodedata
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, List, Optional, Union
@@ -11,6 +15,47 @@ from paradime.tools.pydantic import BaseModel, Extra, root_validator, validator
 
 SCHEDULE_FILE_NAME = "paradime_schedules.yml"
 VALID_ON_EVENTS = ("failed", "passed", "sla")
+
+# Schedule slug format. Mirrors paradb's ScheduleNotificationTemplate slug shape
+# (alphanumeric random prefix + slugified display name) and the format used by
+# the paradime-backend slug validator; keep these constants in sync across repos.
+SLUG_REGEX = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+SLUG_MAX_LENGTH = 80
+SLUG_RANDOM_PREFIX_LENGTH = 6
+_SLUG_PREFIX_ALPHABET = string.ascii_lowercase + string.digits
+_SLUG_SUFFIX_MAX_LENGTH = SLUG_MAX_LENGTH - SLUG_RANDOM_PREFIX_LENGTH - 1
+
+DISPLAY_NAME_MAX_LENGTH = 128
+
+
+def is_valid_slug(name: str) -> bool:
+    return bool(name) and len(name) <= SLUG_MAX_LENGTH and SLUG_REGEX.fullmatch(name) is not None
+
+
+def slugify_display_name(text: str) -> str:
+    if not text:
+        return ""
+    folded = unicodedata.normalize("NFKD", text).encode("ascii", "ignore").decode("ascii").lower()
+    out: List[str] = []
+    prev_hyphen = False
+    for ch in folded:
+        if ch.isalnum():
+            out.append(ch)
+            prev_hyphen = False
+        elif not prev_hyphen:
+            out.append("-")
+            prev_hyphen = True
+    return "".join(out).strip("-")[:_SLUG_SUFFIX_MAX_LENGTH]
+
+
+def mint_schedule_slug(display_name: str) -> str:
+    """Mint `<6-char alnum prefix>-<slugify(display_name)>`. Matches the backend
+    convention so a CLI-minted slug is indistinguishable from a server-minted one."""
+    prefix = "".join(
+        secrets.choice(_SLUG_PREFIX_ALPHABET) for _ in range(SLUG_RANDOM_PREFIX_LENGTH)
+    )
+    suffix = slugify_display_name(display_name) or "schedule"
+    return f"{prefix}-{suffix}"
 
 
 class ParadimeScheduleBase(BaseModel):
@@ -175,6 +220,7 @@ class Integrations(BaseModel):
 
 class ParadimeSchedule(ParadimeScheduleBase):
     name: str
+    display_name: Optional[str] = None
     schedule: str
     timezone: Optional[str] = None
     environment: str
@@ -206,6 +252,18 @@ class ParadimeSchedule(ParadimeScheduleBase):
 
     suspended: Optional[bool] = False
 
+    @validator("display_name")
+    def validate_display_name(cls, display_name: Optional[str]) -> Optional[str]:
+        if display_name is None:
+            return None
+        if "\n" in display_name or "\r" in display_name:
+            raise ValueError("display_name must not contain newlines")
+        if len(display_name) > DISPLAY_NAME_MAX_LENGTH:
+            raise ValueError(
+                f"display_name must be {DISPLAY_NAME_MAX_LENGTH} characters or fewer"
+            )
+        return display_name
+
 
 class ParadimeSchedules(ParadimeScheduleBase):
     version: int = 1
@@ -215,6 +273,25 @@ class ParadimeSchedules(ParadimeScheduleBase):
 @dataclass(frozen=True)
 class Command:
     as_list: List[str]
+
+
+def get_slug_format_warnings(schedules: ParadimeSchedules) -> List[str]:
+    """Names that aren't slug-format yet — informational only.
+
+    The backend grandfathers existing names so deploys keep working, but new
+    schedule names should match the slug format. Surface this as a nudge from
+    `verify` without failing it.
+    """
+    warnings: List[str] = []
+    for schedule in schedules.schedules:
+        if not is_valid_slug(schedule.name):
+            suggested = mint_schedule_slug(schedule.display_name or schedule.name)
+            warnings.append(
+                f"{schedule.name!r} is not in slug format. "
+                f"For new schedules, use a slug like {suggested!r} "
+                f"(lowercase, alphanumeric, hyphen-separated)."
+            )
+    return warnings
 
 
 def is_valid_schedule_at_path(file_path: Path) -> Optional[str]:

--- a/paradime/core/bolt/schedule.py
+++ b/paradime/core/bolt/schedule.py
@@ -1,8 +1,6 @@
 import re
 import secrets
 import shlex
-import string
-import unicodedata
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, List, Optional, Union
@@ -16,14 +14,11 @@ from paradime.tools.pydantic import BaseModel, Extra, root_validator, validator
 SCHEDULE_FILE_NAME = "paradime_schedules.yml"
 VALID_ON_EVENTS = ("failed", "passed", "sla")
 
-# Schedule slug format. Mirrors paradb's ScheduleNotificationTemplate slug shape
-# (alphanumeric random prefix + slugified display name) and the format used by
-# the paradime-backend slug validator; keep these constants in sync across repos.
+# Schedule slug format. Mirrors paradb's schedule slug shape:
+# <first-24-chars-of-name-normalised>-<6-random-hex-chars>.
+# Keep in sync with the paradime-backend slug validator.
 SLUG_REGEX = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 SLUG_MAX_LENGTH = 80
-SLUG_RANDOM_PREFIX_LENGTH = 6
-_SLUG_PREFIX_ALPHABET = string.ascii_lowercase + string.digits
-_SLUG_SUFFIX_MAX_LENGTH = SLUG_MAX_LENGTH - SLUG_RANDOM_PREFIX_LENGTH - 1
 
 DISPLAY_NAME_MAX_LENGTH = 128
 
@@ -32,30 +27,20 @@ def is_valid_slug(name: str) -> bool:
     return bool(name) and len(name) <= SLUG_MAX_LENGTH and SLUG_REGEX.fullmatch(name) is not None
 
 
-def slugify_display_name(text: str) -> str:
-    if not text:
-        return ""
-    folded = unicodedata.normalize("NFKD", text).encode("ascii", "ignore").decode("ascii").lower()
-    out: List[str] = []
-    prev_hyphen = False
-    for ch in folded:
-        if ch.isalnum():
-            out.append(ch)
-            prev_hyphen = False
-        elif not prev_hyphen:
-            out.append("-")
-            prev_hyphen = True
-    return "".join(out).strip("-")[:_SLUG_SUFFIX_MAX_LENGTH]
-
-
 def mint_schedule_slug(display_name: str) -> str:
-    """Mint `<6-char alnum prefix>-<slugify(display_name)>`. Matches the backend
-    convention so a CLI-minted slug is indistinguishable from a server-minted one."""
-    prefix = "".join(
-        secrets.choice(_SLUG_PREFIX_ALPHABET) for _ in range(SLUG_RANDOM_PREFIX_LENGTH)
-    )
-    suffix = slugify_display_name(display_name) or "schedule"
-    return f"{prefix}-{suffix}"
+    """Mint ``<first-24-chars-normalised>-<6-hex>``.
+
+    Same format as the backend's ``mint_schedule_slug`` in paradb. Used locally
+    for suggestion text only; the ``paradime bolt mint`` command calls the backend
+    to mint the canonical slug.
+    """
+    normalised = display_name.lower()
+    normalised = re.sub(r"[^a-z0-9]", "-", normalised)
+    normalised = re.sub(r"-+", "-", normalised)
+    normalised = normalised.strip("-")
+    normalised = normalised[:24]
+    hex_suffix = secrets.token_hex(3)
+    return f"{normalised}-{hex_suffix}"
 
 
 class ParadimeScheduleBase(BaseModel):
@@ -286,8 +271,8 @@ def get_slug_format_warnings(schedules: ParadimeSchedules) -> List[str]:
             suggested = mint_schedule_slug(schedule.display_name or schedule.name)
             warnings.append(
                 f"{schedule.name!r} is not in slug format. "
-                f"For new schedules, use a slug like {suggested!r} "
-                f"(lowercase, alphanumeric, hyphen-separated)."
+                f"Run `paradime bolt mint` to auto-generate slugs, "
+                f"or use a slug like {suggested!r}."
             )
     return warnings
 

--- a/paradime/core/bolt/schedule.py
+++ b/paradime/core/bolt/schedule.py
@@ -369,23 +369,24 @@ def _find_schedule_files(path: Path) -> List[Path]:
 
     # Treat path as a directory (project root).
     root = path if path.is_dir() else path.parent
+    files: List[Path] = []
 
-    # Check .bolt/ directory first
+    # Collect from .bolt/ directory
     bolt_dir = root / SCHEDULES_DIR_NAME
     if bolt_dir.is_dir():
-        files = sorted(
-            p for p in bolt_dir.rglob("*") if p.is_file() and p.suffix in (".yaml", ".yml")
+        files.extend(
+            sorted(
+                p for p in bolt_dir.rglob("*") if p.is_file() and p.suffix in (".yaml", ".yml")
+            )
         )
-        if files:
-            return files
 
-    # Fall back to flat file
+    # Collect flat file(s)
     for name in SCHEDULE_FILE_NAMES:
         flat = root / name
         if flat.is_file():
-            return [flat]
+            files.append(flat)
 
-    return []
+    return files
 
 
 def _get_schedules(path: Path) -> Optional[ParadimeSchedules]:

--- a/paradime/core/bolt/schedule.py
+++ b/paradime/core/bolt/schedule.py
@@ -12,6 +12,8 @@ from paradime.core.bolt.timezones import SUPPORTED_TIMEZONES
 from paradime.tools.pydantic import BaseModel, Extra, root_validator, validator
 
 SCHEDULE_FILE_NAME = "paradime_schedules.yml"
+SCHEDULE_FILE_NAMES = ("paradime_schedules.yml", "paradime_schedules.yaml")
+SCHEDULES_DIR_NAME = ".bolt"
 VALID_ON_EVENTS = ("failed", "passed", "sla")
 
 # Schedule slug format. Mirrors paradb's schedule slug shape:
@@ -354,14 +356,61 @@ def parse_command(command: str) -> Command:
     return Command(as_list=cmd_as_list)
 
 
-def _get_schedules(path: Path) -> Optional[ParadimeSchedules]:
-    """Parse the yaml file."""
+def _find_schedule_files(path: Path) -> List[Path]:
+    """Discover schedule YAML files from a path.
 
-    # Get the schedules.
+    ``path`` can be:
+    - A direct file path (returned as-is if it exists).
+    - A directory that contains ``paradime_schedules.{yml,yaml}`` or a
+      ``.bolt/`` sub-directory with YAML files.
+    """
     if path.is_file():
-        parsed_yaml = yaml.safe_load(path.read_text())
-        return ParadimeSchedules.parse_obj(parsed_yaml)
-    return None
+        return [path]
+
+    # Treat path as a directory (project root).
+    root = path if path.is_dir() else path.parent
+
+    # Check .bolt/ directory first
+    bolt_dir = root / SCHEDULES_DIR_NAME
+    if bolt_dir.is_dir():
+        files = sorted(
+            p for p in bolt_dir.rglob("*") if p.is_file() and p.suffix in (".yaml", ".yml")
+        )
+        if files:
+            return files
+
+    # Fall back to flat file
+    for name in SCHEDULE_FILE_NAMES:
+        flat = root / name
+        if flat.is_file():
+            return [flat]
+
+    return []
+
+
+def _get_schedules(path: Path) -> Optional[ParadimeSchedules]:
+    """Parse schedule YAML file(s).
+
+    Supports a single flat file (``paradime_schedules.{yml,yaml}``) as well as
+    a ``.bolt/`` directory containing multiple YAML files.  When multiple files
+    are found their schedule lists are merged into one ``ParadimeSchedules``.
+    """
+    files = _find_schedule_files(path)
+    if not files:
+        return None
+
+    all_schedules: List[ParadimeSchedule] = []
+    for f in files:
+        parsed_yaml = yaml.safe_load(f.read_text())
+        if not parsed_yaml:
+            continue
+        parsed = ParadimeSchedules.parse_obj(parsed_yaml)
+        all_schedules.extend(parsed.schedules)
+
+    if not all_schedules:
+        return None
+
+    return ParadimeSchedules(schedules=all_schedules)
 
 
 def _cron_schedule_is_non_standard(schedule: str) -> bool:

--- a/paradime/core/bolt/yaml_rewriter.py
+++ b/paradime/core/bolt/yaml_rewriter.py
@@ -50,7 +50,7 @@ def mint_slugs_in_yaml_files(
 
     Args:
         mint_fn: Callable that takes a list of display names and returns slugs.
-                 Typically ``client.bolt.mint_schedule_slugs``.
+                 Typically ``client.bolt.create_schedule_slugs``.
         root: Project root directory containing ``.bolt/`` or ``paradime_schedules.yml``.
         existing_names: Schedule names already deployed in the workspace. These
                         are grandfathered and will not be rewritten, even if they

--- a/paradime/core/bolt/yaml_rewriter.py
+++ b/paradime/core/bolt/yaml_rewriter.py
@@ -9,26 +9,27 @@ from typing import Callable, List, Set
 
 from ruamel.yaml import YAML
 
-from paradime.core.bolt.schedule import SCHEDULE_FILE_NAME, is_valid_slug
-
-SCHEDULES_DIR_NAME = ".bolt"
+from paradime.core.bolt.schedule import SCHEDULE_FILE_NAMES, SCHEDULES_DIR_NAME
 
 
 def _find_yaml_files(root: Path) -> List[Path]:
-    """Discover schedule YAML files — either ``.bolt/*.yaml`` or the flat file."""
+    """Discover schedule YAML files from ``.bolt/`` and/or the flat file."""
+    files: List[Path] = []
+
     bolt_dir = root / SCHEDULES_DIR_NAME
     if bolt_dir.is_dir():
-        files = sorted(
-            p for p in bolt_dir.rglob("*") if p.is_file() and p.suffix in (".yaml", ".yml")
+        files.extend(
+            sorted(
+                p for p in bolt_dir.rglob("*") if p.is_file() and p.suffix in (".yaml", ".yml")
+            )
         )
-        if files:
-            return files
 
-    flat = root / SCHEDULE_FILE_NAME
-    if flat.is_file():
-        return [flat]
+    for name in SCHEDULE_FILE_NAMES:
+        flat = root / name
+        if flat.is_file():
+            files.append(flat)
 
-    return []
+    return files
 
 
 def mint_slugs_in_yaml_files(
@@ -91,13 +92,10 @@ def mint_slugs_in_yaml_files(
                 continue
             name_str = str(name)
 
-            if is_valid_slug(name_str):
-                # Already a slug — record the mapping
+            if name_str in grandfathered:
+                # Exists in the backend — leave it alone
                 display = entry.get("display_name") or name_str
                 name_to_slug[str(display)] = name_str
-                name_to_slug[name_str] = name_str
-            elif name_str in grandfathered:
-                # Exists in backend with this non-slug name — leave it alone
                 name_to_slug[name_str] = name_str
             else:
                 # New schedule, not a slug — needs minting
@@ -126,7 +124,7 @@ def mint_slugs_in_yaml_files(
 
             # Rewrite the schedule's own name (only if not grandfathered)
             name = entry.get("name")
-            if name and not is_valid_slug(str(name)) and str(name) not in grandfathered:
+            if name and str(name) not in grandfathered:
                 old_name = str(name)
                 display = entry.get("display_name") or old_name
                 slug: str | None = name_to_slug.get(str(display)) or name_to_slug.get(old_name)

--- a/paradime/core/bolt/yaml_rewriter.py
+++ b/paradime/core/bolt/yaml_rewriter.py
@@ -111,8 +111,8 @@ def mint_slugs_in_yaml_files(
 
     # Mint slugs from the backend
     minted_slugs = mint_fn(names_needing_slugs)
-    for display_name, slug in zip(names_needing_slugs, minted_slugs):
-        name_to_slug[display_name] = slug
+    for display_name, minted in zip(names_needing_slugs, minted_slugs):
+        name_to_slug[display_name] = minted
 
     # --- Pass 2: rewrite all files ---
     files_changed = 0
@@ -129,10 +129,10 @@ def mint_slugs_in_yaml_files(
             if name and not is_valid_slug(str(name)) and str(name) not in grandfathered:
                 old_name = str(name)
                 display = entry.get("display_name") or old_name
-                slug = name_to_slug.get(str(display), name_to_slug.get(old_name))
+                slug: str | None = name_to_slug.get(str(display)) or name_to_slug.get(old_name)
                 if slug and slug != old_name:
                     if "display_name" not in entry:
-                        entry.insert(1, "display_name", old_name)
+                        entry.insert(1, "display_name", old_name)  # type: ignore[attr-defined]
                     entry["name"] = slug
                     changed = True
 

--- a/paradime/core/bolt/yaml_rewriter.py
+++ b/paradime/core/bolt/yaml_rewriter.py
@@ -7,6 +7,7 @@ modifying the YAML in place.
 from pathlib import Path
 from typing import Callable, List, Set
 
+import click
 from ruamel.yaml import YAML
 
 from paradime.core.bolt.schedule import SCHEDULE_FILE_NAMES, SCHEDULES_DIR_NAME
@@ -65,7 +66,12 @@ def mint_slugs_in_yaml_files(
 
     files = _find_yaml_files(root)
     if not files:
+        click.secho(f"No schedule YAML files found under {root}", fg="yellow")
         return 0
+
+    click.secho(f"Scanning {len(files)} file(s):", fg="cyan")
+    for f in files:
+        click.secho(f"  {f}", fg="cyan")
 
     grandfathered = existing_names or set()
 
@@ -78,9 +84,11 @@ def mint_slugs_in_yaml_files(
     for filepath in files:
         doc = yaml.load(filepath)
         if not doc or "schedules" not in doc:
+            click.secho(f"  Skipping {filepath} (no 'schedules' key)", fg="yellow")
             continue
         schedules = doc.get("schedules")
         if not isinstance(schedules, list):
+            click.secho(f"  Skipping {filepath} ('schedules' is not a list)", fg="yellow")
             continue
         loaded.append((filepath, doc))
 
@@ -93,23 +101,26 @@ def mint_slugs_in_yaml_files(
             name_str = str(name)
 
             if name_str in grandfathered:
-                # Exists in the backend — leave it alone
+                click.secho(f"  {filepath.name}: '{name_str}' exists in backend, skipping.", fg="cyan")
                 display = entry.get("display_name") or name_str
                 name_to_slug[str(display)] = name_str
                 name_to_slug[name_str] = name_str
             else:
-                # New schedule, not a slug — needs minting
                 display = entry.get("display_name") or name_str
+                click.secho(f"  {filepath.name}: '{name_str}' not in backend, will mint slug.", fg="yellow")
                 if str(display) not in names_needing_slugs:
                     names_needing_slugs.append(str(display))
                 name_to_slug[name_str] = name_str  # placeholder, updated below
 
     if not names_needing_slugs:
+        click.secho("No schedules need slug minting.", fg="green")
         return 0
 
     # Mint slugs from the backend
+    click.secho(f"Minting {len(names_needing_slugs)} slug(s) via backend...", fg="cyan")
     minted_slugs = mint_fn(names_needing_slugs)
     for display_name, minted in zip(names_needing_slugs, minted_slugs):
+        click.secho(f"  '{display_name}' -> '{minted}'", fg="green")
         name_to_slug[display_name] = minted
 
     # --- Pass 2: rewrite all files ---
@@ -165,6 +176,7 @@ def mint_slugs_in_yaml_files(
                         changed = True
 
         if changed:
+            click.secho(f"  Rewriting {filepath}", fg="green")
             yaml.dump(doc, filepath)
             files_changed += 1
 

--- a/paradime/core/bolt/yaml_rewriter.py
+++ b/paradime/core/bolt/yaml_rewriter.py
@@ -1,0 +1,173 @@
+"""Rewrite schedule YAML files to mint slugs for non-slug names.
+
+Uses ``ruamel.yaml`` to preserve comments, key order, and formatting when
+modifying the YAML in place.
+"""
+
+from pathlib import Path
+from typing import Callable, List, Set
+
+from ruamel.yaml import YAML
+
+from paradime.core.bolt.schedule import SCHEDULE_FILE_NAME, is_valid_slug
+
+SCHEDULES_DIR_NAME = ".bolt"
+
+
+def _find_yaml_files(root: Path) -> List[Path]:
+    """Discover schedule YAML files — either ``.bolt/*.yaml`` or the flat file."""
+    bolt_dir = root / SCHEDULES_DIR_NAME
+    if bolt_dir.is_dir():
+        files = sorted(
+            p for p in bolt_dir.rglob("*") if p.is_file() and p.suffix in (".yaml", ".yml")
+        )
+        if files:
+            return files
+
+    flat = root / SCHEDULE_FILE_NAME
+    if flat.is_file():
+        return [flat]
+
+    return []
+
+
+def mint_slugs_in_yaml_files(
+    *,
+    mint_fn: Callable[[List[str]], List[str]],
+    root: Path,
+    existing_names: Set[str] | None = None,
+) -> int:
+    """Walk schedule YAML files, mint slugs for non-slug names, rewrite in place.
+
+    Two-pass approach:
+    1. Collect all schedule names across all files. For names that are not valid
+       slugs **and not already deployed** (i.e. not in ``existing_names``), call
+       the backend to mint slugs. Names that already exist in the backend are
+       grandfathered and left unchanged.
+    2. Rewrite all files: update ``name`` fields, set ``display_name``, and fix
+       cross-references in ``deferred_schedule``, ``turbo_ci``, and
+       ``schedule_trigger`` sections.
+
+    Args:
+        mint_fn: Callable that takes a list of display names and returns slugs.
+                 Typically ``client.bolt.mint_schedule_slugs``.
+        root: Project root directory containing ``.bolt/`` or ``paradime_schedules.yml``.
+        existing_names: Schedule names already deployed in the workspace. These
+                        are grandfathered and will not be rewritten, even if they
+                        are not valid slugs.
+
+    Returns:
+        Number of files modified.
+    """
+    yaml = YAML()
+    yaml.preserve_quotes = True
+
+    files = _find_yaml_files(root)
+    if not files:
+        return 0
+
+    grandfathered = existing_names or set()
+
+    # --- Pass 1: load all files and collect names that need slugs ---
+    loaded: list[tuple[Path, dict]] = []
+    names_needing_slugs: list[str] = []  # display names to mint
+    # Track name → slug for all names (both existing and to-be-minted)
+    name_to_slug: dict[str, str] = {}
+
+    for filepath in files:
+        doc = yaml.load(filepath)
+        if not doc or "schedules" not in doc:
+            continue
+        schedules = doc.get("schedules")
+        if not isinstance(schedules, list):
+            continue
+        loaded.append((filepath, doc))
+
+        for entry in schedules:
+            if not isinstance(entry, dict):
+                continue
+            name = entry.get("name")
+            if not name:
+                continue
+            name_str = str(name)
+
+            if is_valid_slug(name_str):
+                # Already a slug — record the mapping
+                display = entry.get("display_name") or name_str
+                name_to_slug[str(display)] = name_str
+                name_to_slug[name_str] = name_str
+            elif name_str in grandfathered:
+                # Exists in backend with this non-slug name — leave it alone
+                name_to_slug[name_str] = name_str
+            else:
+                # New schedule, not a slug — needs minting
+                display = entry.get("display_name") or name_str
+                if str(display) not in names_needing_slugs:
+                    names_needing_slugs.append(str(display))
+                name_to_slug[name_str] = name_str  # placeholder, updated below
+
+    if not names_needing_slugs:
+        return 0
+
+    # Mint slugs from the backend
+    minted_slugs = mint_fn(names_needing_slugs)
+    for display_name, slug in zip(names_needing_slugs, minted_slugs):
+        name_to_slug[display_name] = slug
+
+    # --- Pass 2: rewrite all files ---
+    files_changed = 0
+    for filepath, doc in loaded:
+        changed = False
+        schedules = doc["schedules"]
+
+        for entry in schedules:
+            if not isinstance(entry, dict):
+                continue
+
+            # Rewrite the schedule's own name (only if not grandfathered)
+            name = entry.get("name")
+            if name and not is_valid_slug(str(name)) and str(name) not in grandfathered:
+                old_name = str(name)
+                display = entry.get("display_name") or old_name
+                slug = name_to_slug.get(str(display), name_to_slug.get(old_name))
+                if slug and slug != old_name:
+                    if "display_name" not in entry:
+                        entry.insert(1, "display_name", old_name)
+                    entry["name"] = slug
+                    changed = True
+
+            # Fix deferred_schedule.deferred_schedule_name
+            deferred = entry.get("deferred_schedule")
+            if isinstance(deferred, dict):
+                ref = deferred.get("deferred_schedule_name")
+                if ref and str(ref) in name_to_slug:
+                    new_ref = name_to_slug[str(ref)]
+                    if new_ref != str(ref):
+                        deferred["deferred_schedule_name"] = new_ref
+                        changed = True
+
+            # Fix turbo_ci.deferred_schedule_name
+            turbo = entry.get("turbo_ci")
+            if isinstance(turbo, dict):
+                ref = turbo.get("deferred_schedule_name")
+                if ref and str(ref) in name_to_slug:
+                    new_ref = name_to_slug[str(ref)]
+                    if new_ref != str(ref):
+                        turbo["deferred_schedule_name"] = new_ref
+                        changed = True
+
+            # Fix schedule_trigger.schedule_name
+            trigger = entry.get("schedule_trigger")
+            if isinstance(trigger, dict):
+                ref = trigger.get("schedule_name")
+                if ref and str(ref) in name_to_slug:
+                    new_ref = name_to_slug[str(ref)]
+                    if new_ref != str(ref):
+                        trigger["schedule_name"] = new_ref
+                        changed = True
+
+        if changed:
+            yaml.dump(doc, filepath)
+            files_changed += 1
+
+    return files_changed

--- a/paradime/core/bolt/yaml_rewriter.py
+++ b/paradime/core/bolt/yaml_rewriter.py
@@ -7,7 +7,6 @@ modifying the YAML in place.
 from pathlib import Path
 from typing import Callable, List, Set
 
-import click
 from ruamel.yaml import YAML
 
 from paradime.core.bolt.schedule import SCHEDULE_FILE_NAMES, SCHEDULES_DIR_NAME
@@ -20,9 +19,7 @@ def _find_yaml_files(root: Path) -> List[Path]:
     bolt_dir = root / SCHEDULES_DIR_NAME
     if bolt_dir.is_dir():
         files.extend(
-            sorted(
-                p for p in bolt_dir.rglob("*") if p.is_file() and p.suffix in (".yaml", ".yml")
-            )
+            sorted(p for p in bolt_dir.rglob("*") if p.is_file() and p.suffix in (".yaml", ".yml"))
         )
 
     for name in SCHEDULE_FILE_NAMES:
@@ -66,12 +63,7 @@ def mint_slugs_in_yaml_files(
 
     files = _find_yaml_files(root)
     if not files:
-        click.secho(f"No schedule YAML files found under {root}", fg="yellow")
         return 0
-
-    click.secho(f"Scanning {len(files)} file(s):", fg="cyan")
-    for f in files:
-        click.secho(f"  {f}", fg="cyan")
 
     grandfathered = existing_names or set()
 
@@ -84,11 +76,9 @@ def mint_slugs_in_yaml_files(
     for filepath in files:
         doc = yaml.load(filepath)
         if not doc or "schedules" not in doc:
-            click.secho(f"  Skipping {filepath} (no 'schedules' key)", fg="yellow")
             continue
         schedules = doc.get("schedules")
         if not isinstance(schedules, list):
-            click.secho(f"  Skipping {filepath} ('schedules' is not a list)", fg="yellow")
             continue
         loaded.append((filepath, doc))
 
@@ -101,26 +91,21 @@ def mint_slugs_in_yaml_files(
             name_str = str(name)
 
             if name_str in grandfathered:
-                click.secho(f"  {filepath.name}: '{name_str}' exists in backend, skipping.", fg="cyan")
                 display = entry.get("display_name") or name_str
                 name_to_slug[str(display)] = name_str
                 name_to_slug[name_str] = name_str
             else:
                 display = entry.get("display_name") or name_str
-                click.secho(f"  {filepath.name}: '{name_str}' not in backend, will mint slug.", fg="yellow")
                 if str(display) not in names_needing_slugs:
                     names_needing_slugs.append(str(display))
                 name_to_slug[name_str] = name_str  # placeholder, updated below
 
     if not names_needing_slugs:
-        click.secho("No schedules need slug minting.", fg="green")
         return 0
 
     # Mint slugs from the backend
-    click.secho(f"Minting {len(names_needing_slugs)} slug(s) via backend...", fg="cyan")
     minted_slugs = mint_fn(names_needing_slugs)
     for display_name, minted in zip(names_needing_slugs, minted_slugs):
-        click.secho(f"  '{display_name}' -> '{minted}'", fg="green")
         name_to_slug[display_name] = minted
 
     # --- Pass 2: rewrite all files ---
@@ -176,7 +161,6 @@ def mint_slugs_in_yaml_files(
                         changed = True
 
         if changed:
-            click.secho(f"  Rewriting {filepath}", fg="green")
             yaml.dump(doc, filepath)
             files_changed += 1
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "google-cloud-dataproc>=5.9.0,<6.0.0",
     "google-cloud-datastream>=1.9.0,<2.0.0",
     "google-auth>=2.29.0,<3.0.0",
+    "ruamel.yaml>=0.18.0,<0.19.0",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -942,6 +942,7 @@ dependencies = [
     { name = "pyyaml" },
     { name = "requests" },
     { name = "rich" },
+    { name = "ruamel-yaml" },
     { name = "tenacity" },
 ]
 
@@ -981,6 +982,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0.1,<7.0.0" },
     { name = "requests", specifier = ">=2.31.0,<3.0.0" },
     { name = "rich", specifier = ">=14.0.0,<15.0.0" },
+    { name = "ruamel-yaml", specifier = ">=0.18.0,<0.19.0" },
     { name = "tenacity", specifier = ">=9.0.0,<10.0.0" },
 ]
 
@@ -1385,6 +1387,66 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e9/67/cae617f1351490c25a4b8ac3b8b63a4dda609295d8222bad12242dfdc629/rich-14.3.4.tar.gz", hash = "sha256:817e02727f2b25b40ef56f5aa2217f400c8489f79ca8f46ea2b70dd5e14558a9", size = 230524, upload-time = "2026-04-11T02:57:45.419Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/76/6d163cfac87b632216f71879e6b2cf17163f773ff59c00b5ff4900a80fa3/rich-14.3.4-py3-none-any.whl", hash = "sha256:07e7adb4690f68864777b1450859253bed81a99a31ac321ac1817b2313558952", size = 310480, upload-time = "2026-04-11T02:57:47.484Z" },
+]
+
+[[package]]
+name = "ruamel-yaml"
+version = "0.18.17"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ruamel-yaml-clib", marker = "python_full_version < '3.15' and platform_python_implementation == 'CPython'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3a/2b/7a1f1ebcd6b3f14febdc003e658778d81e76b40df2267904ee6b13f0c5c6/ruamel_yaml-0.18.17.tar.gz", hash = "sha256:9091cd6e2d93a3a4b157ddb8fabf348c3de7f1fb1381346d985b6b247dcd8d3c", size = 149602, upload-time = "2025-12-17T20:02:55.757Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/fe/b6045c782f1fd1ae317d2a6ca1884857ce5c20f59befe6ab25a8603c43a7/ruamel_yaml-0.18.17-py3-none-any.whl", hash = "sha256:9c8ba9eb3e793efdf924b60d521820869d5bf0cb9c6f1b82d82de8295e290b9d", size = 121594, upload-time = "2025-12-17T20:02:07.657Z" },
+]
+
+[[package]]
+name = "ruamel-yaml-clib"
+version = "0.2.15"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ea/97/60fda20e2fb54b83a61ae14648b0817c8f5d84a3821e40bfbdae1437026a/ruamel_yaml_clib-0.2.15.tar.gz", hash = "sha256:46e4cc8c43ef6a94885f72512094e482114a8a706d3c555a34ed4b0d20200600", size = 225794, upload-time = "2025-11-16T16:12:59.761Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/80/8ce7b9af532aa94dd83360f01ce4716264db73de6bc8efd22c32341f6658/ruamel_yaml_clib-0.2.15-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c583229f336682b7212a43d2fa32c30e643d3076178fb9f7a6a14dde85a2d8bd", size = 147998, upload-time = "2025-11-16T16:13:13.241Z" },
+    { url = "https://files.pythonhosted.org/packages/53/09/de9d3f6b6701ced5f276d082ad0f980edf08ca67114523d1b9264cd5e2e0/ruamel_yaml_clib-0.2.15-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:56ea19c157ed8c74b6be51b5fa1c3aff6e289a041575f0556f66e5fb848bb137", size = 132743, upload-time = "2025-11-16T16:13:14.265Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/f7/73a9b517571e214fe5c246698ff3ed232f1ef863c8ae1667486625ec688a/ruamel_yaml_clib-0.2.15-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:5fea0932358e18293407feb921d4f4457db837b67ec1837f87074667449f9401", size = 731459, upload-time = "2025-11-16T20:22:44.338Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/a2/0dc0013169800f1c331a6f55b1282c1f4492a6d32660a0cf7b89e6684919/ruamel_yaml_clib-0.2.15-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef71831bd61fbdb7aa0399d5c4da06bea37107ab5c79ff884cc07f2450910262", size = 749289, upload-time = "2025-11-16T16:13:15.633Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/ed/3fb20a1a96b8dc645d88c4072df481fe06e0289e4d528ebbdcc044ebc8b3/ruamel_yaml_clib-0.2.15-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:617d35dc765715fa86f8c3ccdae1e4229055832c452d4ec20856136acc75053f", size = 777630, upload-time = "2025-11-16T16:13:16.898Z" },
+    { url = "https://files.pythonhosted.org/packages/60/50/6842f4628bc98b7aa4733ab2378346e1441e150935ad3b9f3c3c429d9408/ruamel_yaml_clib-0.2.15-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1b45498cc81a4724a2d42273d6cfc243c0547ad7c6b87b4f774cb7bcc131c98d", size = 744368, upload-time = "2025-11-16T16:13:18.117Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b0/128ae8e19a7d794c2e36130a72b3bb650ce1dd13fb7def6cf10656437dcf/ruamel_yaml_clib-0.2.15-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:def5663361f6771b18646620fca12968aae730132e104688766cf8a3b1d65922", size = 745233, upload-time = "2025-11-16T20:22:45.833Z" },
+    { url = "https://files.pythonhosted.org/packages/75/05/91130633602d6ba7ce3e07f8fc865b40d2a09efd4751c740df89eed5caf9/ruamel_yaml_clib-0.2.15-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:014181cdec565c8745b7cbc4de3bf2cc8ced05183d986e6d1200168e5bb59490", size = 770963, upload-time = "2025-11-16T16:13:19.344Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/4b/fd4542e7f33d7d1bc64cc9ac9ba574ce8cf145569d21f5f20133336cdc8c/ruamel_yaml_clib-0.2.15-cp311-cp311-win32.whl", hash = "sha256:d290eda8f6ada19e1771b54e5706b8f9807e6bb08e873900d5ba114ced13e02c", size = 102640, upload-time = "2025-11-16T16:13:20.498Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/eb/00ff6032c19c7537371e3119287999570867a0eafb0154fccc80e74bf57a/ruamel_yaml_clib-0.2.15-cp311-cp311-win_amd64.whl", hash = "sha256:bdc06ad71173b915167702f55d0f3f027fc61abd975bd308a0968c02db4a4c3e", size = 121996, upload-time = "2025-11-16T16:13:21.855Z" },
+    { url = "https://files.pythonhosted.org/packages/72/4b/5fde11a0722d676e469d3d6f78c6a17591b9c7e0072ca359801c4bd17eee/ruamel_yaml_clib-0.2.15-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:cb15a2e2a90c8475df45c0949793af1ff413acfb0a716b8b94e488ea95ce7cff", size = 149088, upload-time = "2025-11-16T16:13:22.836Z" },
+    { url = "https://files.pythonhosted.org/packages/85/82/4d08ac65ecf0ef3b046421985e66301a242804eb9a62c93ca3437dc94ee0/ruamel_yaml_clib-0.2.15-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:64da03cbe93c1e91af133f5bec37fd24d0d4ba2418eaf970d7166b0a26a148a2", size = 134553, upload-time = "2025-11-16T16:13:24.151Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/cb/22366d68b280e281a932403b76da7a988108287adff2bfa5ce881200107a/ruamel_yaml_clib-0.2.15-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:f6d3655e95a80325b84c4e14c080b2470fe4f33b6846f288379ce36154993fb1", size = 737468, upload-time = "2025-11-16T20:22:47.335Z" },
+    { url = "https://files.pythonhosted.org/packages/71/73/81230babf8c9e33770d43ed9056f603f6f5f9665aea4177a2c30ae48e3f3/ruamel_yaml_clib-0.2.15-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:71845d377c7a47afc6592aacfea738cc8a7e876d586dfba814501d8c53c1ba60", size = 753349, upload-time = "2025-11-16T16:13:26.269Z" },
+    { url = "https://files.pythonhosted.org/packages/61/62/150c841f24cda9e30f588ef396ed83f64cfdc13b92d2f925bb96df337ba9/ruamel_yaml_clib-0.2.15-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:11e5499db1ccbc7f4b41f0565e4f799d863ea720e01d3e99fa0b7b5fcd7802c9", size = 788211, upload-time = "2025-11-16T16:13:27.441Z" },
+    { url = "https://files.pythonhosted.org/packages/30/93/e79bd9cbecc3267499d9ead919bd61f7ddf55d793fb5ef2b1d7d92444f35/ruamel_yaml_clib-0.2.15-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4b293a37dc97e2b1e8a1aec62792d1e52027087c8eea4fc7b5abd2bdafdd6642", size = 743203, upload-time = "2025-11-16T16:13:28.671Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/06/1eb640065c3a27ce92d76157f8efddb184bd484ed2639b712396a20d6dce/ruamel_yaml_clib-0.2.15-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:512571ad41bba04eac7268fe33f7f4742210ca26a81fe0c75357fa682636c690", size = 747292, upload-time = "2025-11-16T20:22:48.584Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/21/ee353e882350beab65fcc47a91b6bdc512cace4358ee327af2962892ff16/ruamel_yaml_clib-0.2.15-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e5e9f630c73a490b758bf14d859a39f375e6999aea5ddd2e2e9da89b9953486a", size = 771624, upload-time = "2025-11-16T16:13:29.853Z" },
+    { url = "https://files.pythonhosted.org/packages/57/34/cc1b94057aa867c963ecf9ea92ac59198ec2ee3a8d22a126af0b4d4be712/ruamel_yaml_clib-0.2.15-cp312-cp312-win32.whl", hash = "sha256:f4421ab780c37210a07d138e56dd4b51f8642187cdfb433eb687fe8c11de0144", size = 100342, upload-time = "2025-11-16T16:13:31.067Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/e5/8925a4208f131b218f9a7e459c0d6fcac8324ae35da269cb437894576366/ruamel_yaml_clib-0.2.15-cp312-cp312-win_amd64.whl", hash = "sha256:2b216904750889133d9222b7b873c199d48ecbb12912aca78970f84a5aa1a4bc", size = 119013, upload-time = "2025-11-16T16:13:32.164Z" },
+    { url = "https://files.pythonhosted.org/packages/17/5e/2f970ce4c573dc30c2f95825f2691c96d55560268ddc67603dc6ea2dd08e/ruamel_yaml_clib-0.2.15-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4dcec721fddbb62e60c2801ba08c87010bd6b700054a09998c4d09c08147b8fb", size = 147450, upload-time = "2025-11-16T16:13:33.542Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/03/a1baa5b94f71383913f21b96172fb3a2eb5576a4637729adbf7cd9f797f8/ruamel_yaml_clib-0.2.15-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:65f48245279f9bb301d1276f9679b82e4c080a1ae25e679f682ac62446fac471", size = 133139, upload-time = "2025-11-16T16:13:34.587Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/19/40d676802390f85784235a05788fd28940923382e3f8b943d25febbb98b7/ruamel_yaml_clib-0.2.15-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:46895c17ead5e22bea5e576f1db7e41cb273e8d062c04a6a49013d9f60996c25", size = 731474, upload-time = "2025-11-16T20:22:49.934Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/bb/6ef5abfa43b48dd55c30d53e997f8f978722f02add61efba31380d73e42e/ruamel_yaml_clib-0.2.15-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3eb199178b08956e5be6288ee0b05b2fb0b5c1f309725ad25d9c6ea7e27f962a", size = 748047, upload-time = "2025-11-16T16:13:35.633Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/5d/e4f84c9c448613e12bd62e90b23aa127ea4c46b697f3d760acc32cb94f25/ruamel_yaml_clib-0.2.15-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4d1032919280ebc04a80e4fb1e93f7a738129857eaec9448310e638c8bccefcf", size = 782129, upload-time = "2025-11-16T16:13:36.781Z" },
+    { url = "https://files.pythonhosted.org/packages/de/4b/e98086e88f76c00c88a6bcf15eae27a1454f661a9eb72b111e6bbb69024d/ruamel_yaml_clib-0.2.15-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ab0df0648d86a7ecbd9c632e8f8d6b21bb21b5fc9d9e095c796cacf32a728d2d", size = 736848, upload-time = "2025-11-16T16:13:37.952Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/5c/5964fcd1fd9acc53b7a3a5d9a05ea4f95ead9495d980003a557deb9769c7/ruamel_yaml_clib-0.2.15-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:331fb180858dd8534f0e61aa243b944f25e73a4dae9962bd44c46d1761126bbf", size = 741630, upload-time = "2025-11-16T20:22:51.718Z" },
+    { url = "https://files.pythonhosted.org/packages/07/1e/99660f5a30fceb58494598e7d15df883a07292346ef5696f0c0ae5dee8c6/ruamel_yaml_clib-0.2.15-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:fd4c928ddf6bce586285daa6d90680b9c291cfd045fc40aad34e445d57b1bf51", size = 766619, upload-time = "2025-11-16T16:13:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/36/2f/fa0344a9327b58b54970e56a27b32416ffbcfe4dcc0700605516708579b2/ruamel_yaml_clib-0.2.15-cp313-cp313-win32.whl", hash = "sha256:bf0846d629e160223805db9fe8cc7aec16aaa11a07310c50c8c7164efa440aec", size = 100171, upload-time = "2025-11-16T16:13:40.456Z" },
+    { url = "https://files.pythonhosted.org/packages/06/c4/c124fbcef0684fcf3c9b72374c2a8c35c94464d8694c50f37eef27f5a145/ruamel_yaml_clib-0.2.15-cp313-cp313-win_amd64.whl", hash = "sha256:45702dfbea1420ba3450bb3dd9a80b33f0badd57539c6aac09f42584303e0db6", size = 118845, upload-time = "2025-11-16T16:13:41.481Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/bd/ab8459c8bb759c14a146990bf07f632c1cbec0910d4853feeee4be2ab8bb/ruamel_yaml_clib-0.2.15-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:753faf20b3a5906faf1fc50e4ddb8c074cb9b251e00b14c18b28492f933ac8ef", size = 147248, upload-time = "2025-11-16T16:13:42.872Z" },
+    { url = "https://files.pythonhosted.org/packages/69/f2/c4cec0a30f1955510fde498aac451d2e52b24afdbcb00204d3a951b772c3/ruamel_yaml_clib-0.2.15-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:480894aee0b29752560a9de46c0e5f84a82602f2bc5c6cde8db9a345319acfdf", size = 133764, upload-time = "2025-11-16T16:13:43.932Z" },
+    { url = "https://files.pythonhosted.org/packages/82/c7/2480d062281385a2ea4f7cc9476712446e0c548cd74090bff92b4b49e898/ruamel_yaml_clib-0.2.15-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:4d3b58ab2454b4747442ac76fab66739c72b1e2bb9bd173d7694b9f9dbc9c000", size = 730537, upload-time = "2025-11-16T20:22:52.918Z" },
+    { url = "https://files.pythonhosted.org/packages/75/08/e365ee305367559f57ba6179d836ecc3d31c7d3fdff2a40ebf6c32823a1f/ruamel_yaml_clib-0.2.15-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bfd309b316228acecfa30670c3887dcedf9b7a44ea39e2101e75d2654522acd4", size = 746944, upload-time = "2025-11-16T16:13:45.338Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/5c/8b56b08db91e569d0a4fbfa3e492ed2026081bdd7e892f63ba1c88a2f548/ruamel_yaml_clib-0.2.15-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2812ff359ec1f30129b62372e5f22a52936fac13d5d21e70373dbca5d64bb97c", size = 778249, upload-time = "2025-11-16T16:13:46.871Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1d/70dbda370bd0e1a92942754c873bd28f513da6198127d1736fa98bb2a16f/ruamel_yaml_clib-0.2.15-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7e74ea87307303ba91073b63e67f2c667e93f05a8c63079ee5b7a5c8d0d7b043", size = 737140, upload-time = "2025-11-16T16:13:48.349Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/87/822d95874216922e1120afb9d3fafa795a18fdd0c444f5c4c382f6dac761/ruamel_yaml_clib-0.2.15-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:713cd68af9dfbe0bb588e144a61aad8dcc00ef92a82d2e87183ca662d242f524", size = 741070, upload-time = "2025-11-16T20:22:54.151Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/17/4e01a602693b572149f92c983c1f25bd608df02c3f5cf50fd1f94e124a59/ruamel_yaml_clib-0.2.15-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:542d77b72786a35563f97069b9379ce762944e67055bea293480f7734b2c7e5e", size = 765882, upload-time = "2025-11-16T16:13:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/17/7999399081d39ebb79e807314de6b611e1d1374458924eb2a489c01fc5ad/ruamel_yaml_clib-0.2.15-cp314-cp314-win32.whl", hash = "sha256:424ead8cef3939d690c4b5c85ef5b52155a231ff8b252961b6516ed7cf05f6aa", size = 102567, upload-time = "2025-11-16T16:13:50.78Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/67/be582a7370fdc9e6846c5be4888a530dcadd055eef5b932e0e85c33c7d73/ruamel_yaml_clib-0.2.15-cp314-cp314-win_amd64.whl", hash = "sha256:ac9b8d5fa4bb7fd2917ab5027f60d4234345fd366fe39aa711d5dca090aa1467", size = 122847, upload-time = "2025-11-16T16:13:51.807Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **Auto-mint schedule slugs** via `paradime bolt verify`: schedules whose `name` is not registered in the backend get a new slug minted via the `createScheduleSlugs` mutation. The current `name` is moved to `display_name` and the minted slug becomes the new `name`.
- **Multi-file schedule discovery**: `bolt verify` now scans both `.bolt/` directory YAML files and `paradime_schedules.{yml,yaml}` flat files, merging all schedules for validation and slug minting.
- **Backend-aware validation**: `deferred_schedule`, `turbo_ci`, and `schedule_trigger` cross-references are validated against both local YAML names and live backend schedule names (via `list_schedules`).
- **YAML rewriting with `ruamel.yaml`**: preserves comments, key order, and formatting when rewriting schedule files in place. Also resolves cross-references to use the newly minted slugs.
- **New API method** `client.bolt.create_schedule_slugs()` calls the `createScheduleSlugs` GraphQL mutation.

## Changed files

- `paradime/cli/bolt.py` — `verify` command: fetches backend schedules, passes them to validation and slug minting, defaults `--path` to `.` for auto-discovery.
- `paradime/core/bolt/schedule.py` — `_find_schedule_files` discovers `.bolt/` + flat files; `_get_schedules` merges multi-file schedules; `is_valid_schedule_at_path` accepts `existing_names` for backend-aware cross-ref validation.
- `paradime/core/bolt/yaml_rewriter.py` — new module: `mint_slugs_in_yaml_files` two-pass rewriter (collect → mint → rewrite).
- `paradime/apis/bolt/client.py` — `create_schedule_slugs` method.
- `pyproject.toml` — added `ruamel.yaml` dependency.

## Test plan

- [ ] Run `paradime bolt verify` in a project with only `paradime_schedules.yml` — verifies flat file discovery
- [ ] Run `paradime bolt verify` in a project with only `.bolt/` directory — verifies directory discovery
- [ ] Run `paradime bolt verify` in a project with both `.bolt/` and `paradime_schedules.yml` — verifies both are scanned
- [ ] Verify that schedules already registered in the backend are not re-minted
- [ ] Verify that `deferred_schedule_name` referencing a backend-only schedule passes validation
- [ ] Verify that `deferred_schedule_name` referencing a non-existent schedule fails validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)