### PR TITLE
ENG-3104 Add cross-workspace schedule trigger validation

### DIFF
--- a/paradime/apis/bolt/client.py
+++ b/paradime/apis/bolt/client.py
@@ -1,5 +1,5 @@
 import time
-from typing import Iterator, List, Optional
+from typing import Iterator, List, Optional, Tuple
 
 import requests
 
@@ -1010,3 +1010,27 @@ class BoltClient:
 
         # Default to False for unknown commands
         return False
+
+    def list_all_schedule_names(self) -> List[Tuple[str, str]]:
+        """List schedule names across all workspaces in the company.
+
+        Unlike ``list_schedules`` (scoped to the API key's workspace), this returns
+        schedules in every workspace, so ``schedule_trigger`` references that point
+        at another workspace can be validated.
+
+        Returns:
+            A list of ``(workspace_name, schedule_name)`` tuples.
+        """
+        query = """
+            query listAllScheduleNames {
+                listAllScheduleNames {
+                    ok
+                    schedules {
+                        name
+                        workspaceName
+                    }
+                }
+            }
+        """
+        response = self.client._call_gql(query=query)["listAllScheduleNames"]
+        return [(s["workspaceName"], s["name"]) for s in response["schedules"]]

--- a/paradime/apis/bolt/client.py
+++ b/paradime/apis/bolt/client.py
@@ -1286,7 +1286,7 @@ class BoltClient:
         """
         response = self.client._call_gql(query=query)["listAllScheduleNames"]
         return [(s["workspaceName"], s["name"]) for s in response["schedules"]]
-    
+
     def create_schedule_slugs(self, display_names: List[str]) -> List[str]:
         """Mint slugs for a list of display names via the backend.
 

--- a/paradime/cli/bolt.py
+++ b/paradime/cli/bolt.py
@@ -272,14 +272,32 @@ def verify(path: str) -> None:
 
     # Fetch existing schedule names from the backend early so we can use
     # them for both validation and slug minting.
-    all_schedules_ref: set[str] = set()
+    #
+    # ``existing_names`` are the current workspace's deployed schedule names
+    # (used for grandfathering, unregistered detection and minting).
+    # ``all_schedules_ref`` are (workspace_name, schedule_name) pairs across all
+    # workspaces (used only to validate cross-workspace schedule_trigger refs).
+    existing_names: set[str] = set()
+    all_schedules_ref: set[tuple[str, str]] = set()
     try:
         client = get_cli_client_or_exit()
-        all_schedules_ref = set(client.bolt.list_all_schedule_names())
+        try:
+            all_schedules = client.bolt.list_schedules(offset=0, limit=10000)
+            existing_names = {s.name for s in all_schedules.schedules}
+        except Exception:
+            pass
+        try:
+            all_schedules_ref = set(client.bolt.list_all_schedule_names())
+        except Exception:
+            pass
     except (ParadimeAPIException, ParadimeException):
         client = None
 
-    error_string = is_valid_schedule_at_path(schedule_path, schedule_trigger_refs=all_schedules_ref)
+    error_string = is_valid_schedule_at_path(
+        schedule_path,
+        existing_names=existing_names,
+        schedule_trigger_refs=all_schedules_ref or None,
+    )
     if error_string:
         print_error_table(error_string, is_json=False)
         sys.exit(1)
@@ -299,13 +317,13 @@ def verify(path: str) -> None:
             client = get_cli_client_or_exit()
         root = schedule_path.parent if schedule_path.is_file() else schedule_path
 
-        unregistered = [s.name for s in schedules.schedules if s.name not in all_schedules_ref]
+        unregistered = [s.name for s in schedules.schedules if s.name not in existing_names]
 
         if unregistered:
             changed = mint_slugs_in_yaml_files(
                 mint_fn=client.bolt.create_schedule_slugs,
                 root=root,
-                existing_names=all_schedules_ref,
+                existing_names=existing_names,
             )
             if changed:
                 click.secho(f"Minted slugs in {changed} file(s).", fg="green")

--- a/paradime/cli/bolt.py
+++ b/paradime/cli/bolt.py
@@ -242,10 +242,8 @@ def verify(path: str) -> None:
     """
     print_version()
 
-    # Fetch schedules across all workspaces so cross-workspace `schedule_trigger`
-    # references can be validated. Tolerate missing credentials / API failure (skip
-    # the check rather than fail verify) by leaving the refs as None, so `verify`
-    # still works offline.
+    # Fetch schedules across all workspaces to validate cross-workspace
+    # schedule_trigger references. Skip the check (refs=None) if offline.
     schedule_trigger_refs = None
     try:
         client = get_cli_client()

--- a/paradime/cli/bolt.py
+++ b/paradime/cli/bolt.py
@@ -22,9 +22,8 @@ from paradime.cli.rich_text_output import (
 )
 from paradime.cli.version import print_version
 from paradime.client.api_exception import ParadimeAPIException, ParadimeException
-from paradime.client.paradime_cli_client import get_cli_client, get_cli_client_or_exit
+from paradime.client.paradime_cli_client import get_cli_client_or_exit
 from paradime.core.bolt.schedule import (
-    SCHEDULE_FILE_NAME,
     _get_schedules,
     get_slug_format_warnings,
     is_valid_schedule_at_path,

--- a/paradime/cli/bolt.py
+++ b/paradime/cli/bolt.py
@@ -251,7 +251,9 @@ def verify(path: str) -> None:
     except Exception:
         schedule_trigger_refs = None
 
-    error_string = is_valid_schedule_at_path(Path(path), schedule_trigger_refs=schedule_trigger_refs)
+    error_string = is_valid_schedule_at_path(
+        Path(path), schedule_trigger_refs=schedule_trigger_refs
+    )
     if error_string:
         print_error_table(error_string, is_json=False)
         sys.exit(1)

--- a/paradime/cli/bolt.py
+++ b/paradime/cli/bolt.py
@@ -22,7 +22,7 @@ from paradime.cli.rich_text_output import (
 )
 from paradime.cli.version import print_version
 from paradime.client.api_exception import ParadimeAPIException, ParadimeException
-from paradime.client.paradime_cli_client import get_cli_client_or_exit
+from paradime.client.paradime_cli_client import get_cli_client, get_cli_client_or_exit
 from paradime.core.bolt.schedule import SCHEDULE_FILE_NAME, is_valid_schedule_at_path
 
 WAIT_SLEEP: Final = 10
@@ -241,7 +241,19 @@ def verify(path: str) -> None:
     Verify the paradime_schedules.yml file.
     """
     print_version()
-    error_string = is_valid_schedule_at_path(Path(path))
+
+    # Fetch schedules across all workspaces so cross-workspace `schedule_trigger`
+    # references can be validated. Tolerate missing credentials / API failure (skip
+    # the check rather than fail verify) by leaving the refs as None, so `verify`
+    # still works offline.
+    schedule_trigger_refs = None
+    try:
+        client = get_cli_client()
+        schedule_trigger_refs = set(client.bolt.list_all_schedule_names())
+    except Exception:
+        schedule_trigger_refs = None
+
+    error_string = is_valid_schedule_at_path(Path(path), schedule_trigger_refs=schedule_trigger_refs)
     if error_string:
         print_error_table(error_string, is_json=False)
         sys.exit(1)

--- a/paradime/core/bolt/schedule.py
+++ b/paradime/core/bolt/schedule.py
@@ -256,10 +256,8 @@ def is_valid_schedule_at_path(
             if schedule.deferred_schedule.deferred_schedule_name not in schedule_names:
                 return f"Deferred schedule error: '{schedule.deferred_schedule.deferred_schedule_name}' does not refer to another schedule name"
 
-        # schedule_trigger can point at a schedule in any workspace. When we have
-        # the list of schedules across all workspaces, validate the
-        # (workspace_name, schedule_name) pair against it. A local schedule in this
-        # same file is also accepted (it may not be deployed yet).
+        # schedule_trigger may point at a schedule in any workspace; validate the
+        # (workspace_name, schedule_name) pair (a local schedule also counts).
         if schedule.schedule_trigger and schedule.schedule_trigger.enabled and schedule_trigger_refs:
             trigger = schedule.schedule_trigger
             ref = (trigger.workspace_name, trigger.schedule_name)

--- a/paradime/core/bolt/schedule.py
+++ b/paradime/core/bolt/schedule.py
@@ -1,7 +1,7 @@
 import shlex
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, List, Optional, Union
+from typing import Any, List, Optional, Set, Tuple, Union
 
 import yaml  # type: ignore[import-untyped]
 from croniter import croniter  # type: ignore[import-untyped]
@@ -217,7 +217,21 @@ class Command:
     as_list: List[str]
 
 
-def is_valid_schedule_at_path(file_path: Path) -> Optional[str]:
+def is_valid_schedule_at_path(
+    file_path: Path,
+    schedule_trigger_refs: Optional[Set[Tuple[str, str]]] = None,
+) -> Optional[str]:
+    """Validate a schedule YAML file.
+
+    Args:
+        file_path: Path to the schedule YAML file.
+        schedule_trigger_refs: Optional set of ``(workspace_name, schedule_name)``
+            pairs for schedules deployed across all workspaces. When provided,
+            ``schedule_trigger`` references are validated against it (a
+            ``schedule_trigger`` may point at a schedule in another workspace).
+            When ``None`` (e.g. offline / API unavailable) the cross-workspace
+            check is skipped.
+    """
     try:
         schedules = _get_schedules(file_path)
     except Exception as e:
@@ -241,6 +255,19 @@ def is_valid_schedule_at_path(file_path: Path) -> Optional[str]:
         if schedule.deferred_schedule and schedule.deferred_schedule.enabled:
             if schedule.deferred_schedule.deferred_schedule_name not in schedule_names:
                 return f"Deferred schedule error: '{schedule.deferred_schedule.deferred_schedule_name}' does not refer to another schedule name"
+
+        # schedule_trigger can point at a schedule in any workspace. When we have
+        # the list of schedules across all workspaces, validate the
+        # (workspace_name, schedule_name) pair against it. A local schedule in this
+        # same file is also accepted (it may not be deployed yet).
+        if schedule.schedule_trigger and schedule.schedule_trigger.enabled and schedule_trigger_refs:
+            trigger = schedule.schedule_trigger
+            ref = (trigger.workspace_name, trigger.schedule_name)
+            if ref not in schedule_trigger_refs and trigger.schedule_name not in schedule_names:
+                return (
+                    f"Schedule trigger error: '{trigger.schedule_name}' does not refer to a known "
+                    f"schedule in workspace '{trigger.workspace_name}'"
+                )
 
     # Verify schedules individually
     for schedule in schedules.schedules:

--- a/paradime/core/bolt/schedule.py
+++ b/paradime/core/bolt/schedule.py
@@ -258,7 +258,11 @@ def is_valid_schedule_at_path(
 
         # schedule_trigger may point at a schedule in any workspace; validate the
         # (workspace_name, schedule_name) pair (a local schedule also counts).
-        if schedule.schedule_trigger and schedule.schedule_trigger.enabled and schedule_trigger_refs:
+        if (
+            schedule.schedule_trigger
+            and schedule.schedule_trigger.enabled
+            and schedule_trigger_refs
+        ):
             trigger = schedule.schedule_trigger
             ref = (trigger.workspace_name, trigger.schedule_name)
             if ref not in schedule_trigger_refs and trigger.schedule_name not in schedule_names:

--- a/paradime/core/bolt/schedule.py
+++ b/paradime/core/bolt/schedule.py
@@ -281,12 +281,17 @@ def get_slug_format_warnings(schedules: ParadimeSchedules) -> List[str]:
 
 def is_valid_schedule_at_path(
     file_path: Path,
+    existing_names: Optional[Set[str]] = None,
     schedule_trigger_refs: Optional[Set[Tuple[str, str]]] = None,
 ) -> Optional[str]:
     """Validate a schedule YAML file.
 
     Args:
         file_path: Path to the schedule YAML file.
+        existing_names: Optional set of schedule names already deployed in the
+            current workspace. When provided, ``turbo_ci`` / ``deferred_schedule``
+            references are allowed to resolve to these names in addition to the
+            local YAML names (grandfathering of already-deployed schedules).
         schedule_trigger_refs: Optional set of ``(workspace_name, schedule_name)``
             pairs for schedules deployed across all workspaces. When provided,
             ``schedule_trigger`` references are validated against it (a


### PR DESCRIPTION
## Summary
This PR adds support for validating `schedule_trigger` references that point to schedules in other workspaces. Previously, the schedule validation only checked for local schedule references within the same file.

## Key Changes
- **Enhanced `is_valid_schedule_at_path()` function**: Added optional `schedule_trigger_refs` parameter to accept a set of `(workspace_name, schedule_name)` tuples representing all schedules across workspaces. When provided, cross-workspace `schedule_trigger` references are validated against this set.

- **New `list_all_schedule_names()` API method**: Added to `BoltClient` to fetch schedule names across all workspaces in the company, enabling validation of cross-workspace schedule references.

- **Updated `verify` CLI command**: Modified to fetch all schedule names across workspaces and pass them to the validation function. The implementation gracefully handles API failures by skipping the cross-workspace validation check, allowing `verify` to work offline.

## Implementation Details
- The validation accepts both local schedules (in the same file) and cross-workspace references when `schedule_trigger_refs` is provided
- When `schedule_trigger_refs` is `None` (e.g., offline or API unavailable), the cross-workspace check is skipped but local validation continues
- The GraphQL query `listAllScheduleNames` returns workspace and schedule name pairs for all schedules in the company
- Error messages clearly indicate when a schedule trigger references an unknown schedule in a specific workspace

https://claude.ai/code/session_01VF8UfQENji6q6YALsub55Q