### PR TITLE
Add internal transport mode and Slack verification to bolt verify

### DIFF
--- a/paradime/cli/bolt.py
+++ b/paradime/cli/bolt.py
@@ -23,6 +23,7 @@ from paradime.cli.rich_text_output import (
 from paradime.cli.version import print_version
 from paradime.client.api_exception import ParadimeAPIException, ParadimeException
 from paradime.client.paradime_cli_client import get_cli_client_or_exit
+from paradime.core.bolt import internal_transport
 from paradime.core.bolt.schedule import (
     _get_schedules,
     get_slug_format_warnings,
@@ -244,16 +245,13 @@ def retry(retry_all: bool, wait: bool, json: bool, run_id: int) -> None:
         _wait_with_logs(client, new_run_id, is_json=json)
 
 
-@click.command()
-@click.option(
-    "--path",
-    help="Path to paradime_schedules.yml file or project root containing .bolt/ directory.",
-    show_default=True,
-    default=".",
-)
-def verify(path: str) -> None:
-    """
-    Verify schedule YAML files and mint slugs for new schedules.
+def run_bolt_verify(path: str) -> int:
+    """Verify schedule YAML files and mint slugs for new schedules.
+
+    This is the single source of truth for ``paradime bolt verify`` (external,
+    GraphQL-backed) and the Theia editor's ``paradime schedule verify``
+    (internal, REST-backed). The transport is chosen automatically from
+    ``PARADIME_INTERNAL_MODE`` (see ``internal_transport``).
 
     Validates the schedule configuration, then checks for schedules whose
     ``name`` is not a valid slug. For those, calls the Paradime backend to
@@ -265,6 +263,8 @@ def verify(path: str) -> None:
 
     Supports both the flat ``paradime_schedules.yml`` layout and the modular
     ``.bolt/`` folder layout.
+
+    Returns a process exit code (0 on success, non-zero on validation failure).
     """
     print_version()
     schedule_path = Path(path)
@@ -276,30 +276,48 @@ def verify(path: str) -> None:
     # (used for grandfathering, unregistered detection and minting).
     # ``all_schedules_ref`` are (workspace_name, schedule_name) pairs across all
     # workspaces (used only to validate cross-workspace schedule_trigger refs).
+    #
+    # Two transports back these calls. In the default (external) mode the SDK
+    # talks to the public GraphQL API with an API key/secret. In internal mode
+    # (``PARADIME_INTERNAL_MODE`` set, e.g. inside a Theia editor pod) it uses the
+    # backend's company-scoped internal REST endpoints, which need no key/secret
+    # and are only reachable from within the network perimeter.
     existing_names: set[str] = set()
     all_schedules_ref: set[tuple[str, str]] = set()
-    try:
-        client = get_cli_client_or_exit()
+    slack_id_verifier = None
+    mint_fn = None
+
+    if internal_transport.is_internal_mode():
+        deployed = internal_transport.list_existing_schedules()
+        existing_names = internal_transport.current_workspace_names(deployed)
+        all_schedules_ref = internal_transport.all_workspace_refs(deployed)
+        slack_id_verifier = internal_transport.verify_slack_ids
+        mint_fn = internal_transport.create_schedule_slugs
+    else:
         try:
-            all_schedules = client.bolt.list_schedules(offset=0, limit=10000)
-            existing_names = {s.name for s in all_schedules.schedules}
-        except Exception:
-            pass
-        try:
-            all_schedules_ref = set(client.bolt.list_all_schedule_names())
-        except Exception:
-            pass
-    except (ParadimeAPIException, ParadimeException):
-        client = None
+            client = get_cli_client_or_exit()
+            try:
+                all_schedules = client.bolt.list_schedules(offset=0, limit=10000)
+                existing_names = {s.name for s in all_schedules.schedules}
+            except Exception:
+                pass
+            try:
+                all_schedules_ref = set(client.bolt.list_all_schedule_names())
+            except Exception:
+                pass
+            mint_fn = client.bolt.create_schedule_slugs
+        except (ParadimeAPIException, ParadimeException):
+            client = None
 
     error_string = is_valid_schedule_at_path(
         schedule_path,
         existing_names=existing_names,
         schedule_trigger_refs=all_schedules_ref or None,
+        slack_id_verifier=slack_id_verifier,
     )
     if error_string:
         print_error_table(error_string, is_json=False)
-        sys.exit(1)
+        return 1
 
     # Check for names not yet registered in the backend and mint slugs.
     try:
@@ -309,18 +327,19 @@ def verify(path: str) -> None:
 
     if not schedules:
         click.secho("No schedules found.", fg="yellow")
-        return
+        return 0
 
     try:
-        if not client:
+        if mint_fn is None:
             client = get_cli_client_or_exit()
+            mint_fn = client.bolt.create_schedule_slugs
         root = schedule_path.parent if schedule_path.is_file() else schedule_path
 
         unregistered = [s.name for s in schedules.schedules if s.name not in existing_names]
 
         if unregistered:
             changed = mint_slugs_in_yaml_files(
-                mint_fn=client.bolt.create_schedule_slugs,
+                mint_fn=mint_fn,
                 root=root,
                 existing_names=existing_names,
             )
@@ -341,6 +360,20 @@ def verify(path: str) -> None:
         if schedules:
             for warning in get_slug_format_warnings(schedules):
                 click.secho(f"warning: {warning}", fg="yellow")
+
+    return 0
+
+
+@click.command()
+@click.option(
+    "--path",
+    help="Path to paradime_schedules.yml file or project root containing .bolt/ directory.",
+    show_default=True,
+    default=".",
+)
+def verify(path: str) -> None:
+    """Verify schedule YAML files and mint slugs for new schedules."""
+    sys.exit(run_bolt_verify(path))
 
 
 @click.command()

--- a/paradime/cli/bolt.py
+++ b/paradime/cli/bolt.py
@@ -330,7 +330,7 @@ def run_bolt_verify(path: str) -> int:
         _console.result_panel(
             "No schedules found.", style="warning", title="Schedules Verification"
         )
-        return
+        return 1
 
     try:
         if mint_fn is None:

--- a/paradime/core/bolt/internal_transport.py
+++ b/paradime/core/bolt/internal_transport.py
@@ -1,0 +1,158 @@
+"""Internal-mode transport for ``paradime bolt verify``.
+
+When the CLI runs *inside* the Paradime cluster (e.g. the in-IDE terminal of a
+Theia editor pod) it cannot use the public GraphQL API: those pods carry a
+``COMPANY_TOKEN`` but no API key/secret. They can, however, reach the backend's
+unauthenticated, company-scoped internal REST endpoints over cluster-internal
+DNS, which is not routable from outside the network perimeter.
+
+This module mirrors the surface ``verify`` needs (existing schedule names,
+cross-workspace references, slug minting, Slack-ID checks) but talks to those
+internal REST endpoints instead of GraphQL. It is selected by ``verify`` when
+``PARADIME_INTERNAL_MODE`` is truthy; the endpoint URLs are injected via Helm
+(``LIST_SCHEDULE_NAMES_URL``, ``CREATE_SCHEDULE_SLUGS_URL``,
+``SLACK_ID_EXISTS_URL``).
+
+Setting ``PARADIME_INTERNAL_MODE`` outside the cluster confers nothing: the URLs
+point at internal-only DNS, so the requests simply fail to connect. The network
+perimeter — not this flag — is the security boundary.
+"""
+
+import json
+import os
+from typing import Dict, List, Optional, Set, Tuple
+
+import requests
+
+
+def is_internal_mode() -> bool:
+    """Whether the CLI should use the internal REST transport."""
+    return os.getenv("PARADIME_INTERNAL_MODE", "").strip().lower() in ("1", "true", "yes")
+
+
+def _workspace_uid() -> str:
+    # Theia historically read this under two different casings; honour both so we
+    # stay compatible regardless of how the pod env is populated.
+    return os.getenv("WORKSPACE_UID") or os.getenv("workspace_uid") or ""
+
+
+def list_existing_schedules() -> List[Dict[str, str]]:
+    """List schedule names across all workspaces in the company.
+
+    Returns a list of ``{"name", "workspace_name", "workspace_uid"}`` dicts, or
+    an empty list on any error so ``verify`` keeps working when the backend is
+    unreachable.
+    """
+    try:
+        url = os.getenv("LIST_SCHEDULE_NAMES_URL")
+        if not url:
+            return []
+
+        r = requests.get(url)
+        if r.status_code != 200:
+            if os.getenv("VERBOSE_LOGS", False):
+                print(r.text)
+            return []
+
+        r_json = r.json()
+        if not r_json.get("ok", False):
+            return []
+
+        schedules = r_json.get("schedules")
+        if not isinstance(schedules, list):
+            return []
+        return [s for s in schedules if isinstance(s, dict)]
+    except Exception as e:
+        if os.getenv("VERBOSE_LOGS", False):
+            print(f"Problem listing existing schedules: {e}")
+        return []
+
+
+def current_workspace_names(schedules: List[Dict[str, str]]) -> Set[str]:
+    """Names of schedules deployed in the current workspace (by ``WORKSPACE_UID``).
+
+    When no workspace UID is available, every deployed name is treated as
+    current-workspace (the historical Theia behaviour).
+    """
+    workspace_uid = _workspace_uid()
+    return {
+        s["name"]
+        for s in schedules
+        if s.get("name") and (not workspace_uid or s.get("workspace_uid") == workspace_uid)
+    }
+
+
+def all_workspace_refs(schedules: List[Dict[str, str]]) -> Set[Tuple[str, str]]:
+    """``(workspace_name, schedule_name)`` pairs across all workspaces.
+
+    Used to validate cross-workspace ``schedule_trigger`` references.
+    """
+    return {
+        (s["workspace_name"], s["name"])
+        for s in schedules
+        if s.get("name") and s.get("workspace_name")
+    }
+
+
+def create_schedule_slugs(display_names: List[str]) -> List[str]:
+    """Mint a slug for each display name via the backend.
+
+    Returns slugs order-aligned with ``display_names``. Raises on any failure so
+    the caller can fall back gracefully.
+    """
+    if not display_names:
+        return []
+
+    url = os.getenv("CREATE_SCHEDULE_SLUGS_URL")
+    if not url:
+        raise RuntimeError("CREATE_SCHEDULE_SLUGS_URL is not configured.")
+
+    r = requests.post(url, data=json.dumps({"display_names": display_names}))
+    if r.status_code != 200:
+        raise RuntimeError(f"Failed to mint slugs (status {r.status_code}).")
+
+    r_json = r.json()
+    if not r_json.get("ok", False):
+        raise RuntimeError("Backend returned ok=False while minting slugs.")
+
+    slugs = r_json.get("slugs")
+    if not isinstance(slugs, list) or len(slugs) != len(display_names):
+        raise RuntimeError("Backend returned an unexpected number of slugs.")
+    return slugs
+
+
+def verify_slack_ids(slack_ids: List[str]) -> Tuple[bool, Optional[Dict[str, bool]]]:
+    """Check whether each Slack ID is accessible to the Paradime Slack bot.
+
+    Returns ``(ok, ids_with_status)`` where ``ids_with_status`` maps each Slack
+    ID to whether it is reachable. ``ok`` is ``False`` (with ``None`` status) when
+    Slack is not connected or the endpoint cannot be reached.
+    """
+    if not slack_ids:
+        return True, None
+    try:
+        url = os.getenv("SLACK_ID_EXISTS_URL")
+        if not url:
+            print("Slack verification is not configured.")
+            return False, None
+
+        r = requests.post(
+            url, data=json.dumps({"ids": slack_ids, "workspace_uid": _workspace_uid()})
+        )
+        if r.status_code != 200:
+            print("Problem verifying slack IDs. Please try again later.")
+            if os.getenv("VERBOSE_LOGS", False):
+                print(r.text)
+            return False, None
+
+        r_json = r.json()
+        if not r_json.get("ok", False):
+            print(
+                "Slack is not connected. Please connect at: "
+                "https://app.paradime.io/account-settings/integrations"
+            )
+            return False, None
+    except Exception as e:
+        print(f"Problem querying slack: {e}")
+        return False, None
+    return True, r_json.get("ids_with_status")

--- a/paradime/core/bolt/schedule.py
+++ b/paradime/core/bolt/schedule.py
@@ -1,9 +1,11 @@
+import json
+import os
 import re
 import secrets
 import shlex
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, List, Optional, Set, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
 
 import yaml  # type: ignore[import-untyped]
 from croniter import croniter  # type: ignore[import-untyped]
@@ -15,6 +17,17 @@ SCHEDULE_FILE_NAME = "paradime_schedules.yml"
 SCHEDULE_FILE_NAMES = ("paradime_schedules.yml", "paradime_schedules.yaml")
 SCHEDULES_DIR_NAME = ".bolt"
 VALID_ON_EVENTS = ("failed", "passed", "sla")
+
+# Commands a schedule is allowed to run. Mirrors the backend's allow-list
+# (enforced again at deploy time). The default can be overridden — e.g. when the
+# backend extends the list via a feature flag — through the ``BOLT_ALLOWED_COMMANDS``
+# environment variable (a JSON array of strings).
+ALLOWED_COMMANDS = ["dbt", "re_data", "edr", "lightdash", "python"]
+
+# A callable that, given a list of Slack IDs, returns ``(ok, ids_with_status)``
+# where ``ids_with_status`` maps each Slack ID to whether it is reachable by the
+# Paradime Slack bot. ``ok`` is ``False`` when Slack could not be reached at all.
+SlackIdVerifier = Callable[[List[str]], Tuple[bool, Optional[Dict[str, bool]]]]
 
 # Schedule slug format. Mirrors paradb's schedule slug shape:
 # <first-24-chars-of-name-normalised>-<6-random-hex-chars>.
@@ -205,6 +218,17 @@ class Integrations(BaseModel):
         extra = Extra.allow
 
 
+class SelfHealingConfig(BaseModel):
+    enabled: bool = False
+    slack_channel: Optional[str] = None
+    agent_name: Optional[str] = None
+
+
+class EnvOverride(ParadimeScheduleBase):
+    key: str
+    value: str
+
+
 class ParadimeSchedule(ParadimeScheduleBase):
     name: str
     display_name: Optional[str] = None
@@ -237,7 +261,11 @@ class ParadimeSchedule(ParadimeScheduleBase):
 
     trigger_on_merge: Optional[bool] = False
 
+    self_healing: Optional[SelfHealingConfig] = None
+
     suspended: Optional[bool] = False
+
+    env_overrides: Optional[List[EnvOverride]] = None
 
     @validator("display_name")
     def validate_display_name(cls, display_name: Optional[str]) -> Optional[str]:
@@ -248,6 +276,33 @@ class ParadimeSchedule(ParadimeScheduleBase):
         if len(display_name) > DISPLAY_NAME_MAX_LENGTH:
             raise ValueError(f"display_name must be {DISPLAY_NAME_MAX_LENGTH} characters or fewer")
         return display_name
+
+    @root_validator()
+    @classmethod
+    def validate_self_healing_slack_channel(cls, values: Any) -> Any:
+        # self_healing.slack_channel must appear in notifications.slack_channels —
+        # the agent replies into the thread created by the standard notification.
+        self_healing = values.get("self_healing")
+        if not (self_healing and self_healing.enabled and self_healing.slack_channel):
+            return values
+
+        notifications = values.get("notifications")
+        configured: set = set()
+        if notifications and notifications.slack_channels:
+            configured = {c.get_channel() for c in notifications.slack_channels}
+
+        slack_notify = values.get("slack_notify")
+        if isinstance(slack_notify, str):
+            configured.add(slack_notify)
+        elif isinstance(slack_notify, list):
+            configured.update(c for c in slack_notify if c)
+
+        if self_healing.slack_channel not in configured:
+            raise ValueError(
+                f"self_healing.slack_channel '{self_healing.slack_channel}' must also "
+                f"appear in notifications.slack_channels for this schedule"
+            )
+        return values
 
 
 class ParadimeSchedules(ParadimeScheduleBase):
@@ -283,6 +338,7 @@ def is_valid_schedule_at_path(
     file_path: Path,
     existing_names: Optional[Set[str]] = None,
     schedule_trigger_refs: Optional[Set[Tuple[str, str]]] = None,
+    slack_id_verifier: Optional[SlackIdVerifier] = None,
 ) -> Optional[str]:
     """Validate a schedule YAML file.
 
@@ -298,6 +354,10 @@ def is_valid_schedule_at_path(
             ``schedule_trigger`` may point at a schedule in another workspace).
             When ``None`` (e.g. offline / API unavailable) the cross-workspace
             check is skipped.
+        slack_id_verifier: Optional callable used to check that each schedule's
+            Slack notification IDs are reachable by the Paradime Slack bot. When
+            ``None`` (e.g. the public API has no Slack-check endpoint) the check
+            is skipped.
     """
     try:
         schedules = _get_schedules(file_path)
@@ -345,18 +405,57 @@ def is_valid_schedule_at_path(
 
     # Verify schedules individually
     for schedule in schedules.schedules:
-        if error := verify_single_schedule(schedule):
+        if error := verify_single_schedule(schedule, slack_id_verifier=slack_id_verifier):
             return error
 
     return None
 
 
-def verify_single_schedule(schedule: ParadimeSchedule) -> Optional[str]:
+def get_allowed_commands() -> List[str]:
+    """Allowed commands, overridable via the ``BOLT_ALLOWED_COMMANDS`` env var.
+
+    The env var, when set, must be a JSON array of strings; otherwise the
+    hardcoded default (``ALLOWED_COMMANDS``) is used.
+    """
+    env_value = os.environ.get("BOLT_ALLOWED_COMMANDS", "")
+    if env_value:
+        try:
+            commands = json.loads(env_value)
+            if isinstance(commands, list) and commands:
+                return commands
+        except (json.JSONDecodeError, TypeError):
+            pass
+    return list(ALLOWED_COMMANDS)
+
+
+def is_allowed_command(command: Command, allowed_commands: List[str]) -> bool:
+    cmd = command.as_list
+    return bool(cmd) and cmd[0] in allowed_commands
+
+
+def verify_single_schedule(
+    schedule: ParadimeSchedule,
+    slack_id_verifier: Optional[SlackIdVerifier] = None,
+) -> Optional[str]:
     schedule_name = schedule.name
 
     # check there are commands
     if not schedule.commands:
         return f"{schedule_name}: Missing commands."
+
+    # check each command starts with an allowed command
+    allowed_commands = get_allowed_commands()
+    for command in schedule.commands:
+        if not is_allowed_command(parse_command(command), allowed_commands):
+            return (
+                f"{schedule_name}: Command {command!r} is not an allowed command. "
+                f"Allowed commands are: {allowed_commands}."
+            )
+
+    # verify slack ids are reachable by the Paradime Slack bot
+    if slack_id_verifier is not None:
+        if error := _verify_slack_ids(schedule, slack_id_verifier):
+            return error
 
     # verify cron schedule
     if (
@@ -385,6 +484,30 @@ def verify_single_schedule(schedule: ParadimeSchedule) -> Optional[str]:
                     f"{schedule_name}: Email on '{email_on}' is not valid - use: {VALID_ON_EVENTS}."
                 )
 
+    return None
+
+
+def _verify_slack_ids(
+    schedule: ParadimeSchedule,
+    slack_id_verifier: SlackIdVerifier,
+) -> Optional[str]:
+    """Check the schedule's Slack notification IDs via ``slack_id_verifier``."""
+    raw = schedule.slack_notify
+    slack_ids = [raw] if isinstance(raw, str) else list(raw)
+    slack_ids = [slack_id for slack_id in slack_ids if slack_id]
+    if not slack_ids:
+        return None
+
+    ok, ids_with_status = slack_id_verifier(slack_ids)
+    if not ok:
+        return f"{schedule.name}: Problem communicating with Slack."
+    if ids_with_status:
+        for slack_id, id_is_valid in ids_with_status.items():
+            if not id_is_valid:
+                return (
+                    f"{schedule.name}: Slack ID '{slack_id}' is not accessible to "
+                    f"the Paradime Slack bot."
+                )
     return None
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "paradime-io"
-version = "5.9.0"
+version = "5.10.0"
 description = "Paradime - Python SDK"
 authors = [
     { name = "Bhuvan Singla", email = "bhuvan@paradime.io" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "paradime-io"
-version = "5.8.0"
+version = "5.9.0"
 description = "Paradime - Python SDK"
 authors = [
     { name = "Bhuvan Singla", email = "bhuvan@paradime.io" },

--- a/tests/test_bolt_verify.py
+++ b/tests/test_bolt_verify.py
@@ -56,9 +56,7 @@ def test_slack_verifier_flags_unreachable_id():
     def verifier(ids: List[str]) -> Tuple[bool, Optional[Dict[str, bool]]]:
         return True, {ids[0]: False}
 
-    error = verify_single_schedule(
-        _schedule(slack_notify=["U123"]), slack_id_verifier=verifier
-    )
+    error = verify_single_schedule(_schedule(slack_notify=["U123"]), slack_id_verifier=verifier)
     assert error is not None
     assert "not accessible" in error
 
@@ -68,8 +66,7 @@ def test_slack_verifier_passes_when_reachable():
         return True, {ids[0]: True}
 
     assert (
-        verify_single_schedule(_schedule(slack_notify=["U123"]), slack_id_verifier=verifier)
-        is None
+        verify_single_schedule(_schedule(slack_notify=["U123"]), slack_id_verifier=verifier) is None
     )
 
 

--- a/tests/test_bolt_verify.py
+++ b/tests/test_bolt_verify.py
@@ -1,0 +1,101 @@
+"""Unit tests for the consolidated ``bolt verify`` logic.
+
+These cover the parity additions made when the Theia editor's
+``paradime schedule verify`` was consolidated onto the SDK:
+- the command allow-list,
+- Slack-ID verification threading,
+- ``self_healing`` / ``env_overrides`` schedule fields,
+- internal-mode transport selection.
+"""
+
+from typing import Dict, List, Optional, Tuple
+
+import pytest
+
+from paradime.core.bolt import internal_transport
+from paradime.core.bolt.schedule import (
+    ParadimeSchedules,
+    get_allowed_commands,
+    verify_single_schedule,
+)
+
+
+def _schedule(**overrides):
+    base = {
+        "name": "my-schedule",
+        "schedule": "0 1 * * *",
+        "environment": "production",
+        "commands": ["dbt run"],
+    }
+    base.update(overrides)
+    return ParadimeSchedules.parse_obj({"schedules": [base]}).schedules[0]
+
+
+def test_allowed_command_passes():
+    assert verify_single_schedule(_schedule(commands=["dbt run"])) is None
+
+
+def test_disallowed_command_rejected():
+    error = verify_single_schedule(_schedule(commands=["rm -rf /"]))
+    assert error is not None
+    assert "not an allowed command" in error
+
+
+def test_allowed_commands_env_override(monkeypatch):
+    monkeypatch.setenv("BOLT_ALLOWED_COMMANDS", '["dbt", "custom_tool"]')
+    assert "custom_tool" in get_allowed_commands()
+    assert verify_single_schedule(_schedule(commands=["custom_tool sync"])) is None
+
+
+def test_allowed_commands_env_override_invalid_falls_back(monkeypatch):
+    monkeypatch.setenv("BOLT_ALLOWED_COMMANDS", "not-json")
+    assert verify_single_schedule(_schedule(commands=["python foo.py"])) is None
+
+
+def test_slack_verifier_flags_unreachable_id():
+    def verifier(ids: List[str]) -> Tuple[bool, Optional[Dict[str, bool]]]:
+        return True, {ids[0]: False}
+
+    error = verify_single_schedule(
+        _schedule(slack_notify=["U123"]), slack_id_verifier=verifier
+    )
+    assert error is not None
+    assert "not accessible" in error
+
+
+def test_slack_verifier_passes_when_reachable():
+    def verifier(ids: List[str]) -> Tuple[bool, Optional[Dict[str, bool]]]:
+        return True, {ids[0]: True}
+
+    assert (
+        verify_single_schedule(_schedule(slack_notify=["U123"]), slack_id_verifier=verifier)
+        is None
+    )
+
+
+def test_slack_check_skipped_without_verifier():
+    # External mode passes no verifier; Slack IDs must not be validated.
+    assert verify_single_schedule(_schedule(slack_notify=["U123"])) is None
+
+
+def test_self_healing_requires_channel_in_notifications():
+    with pytest.raises(Exception):
+        _schedule(
+            self_healing={"enabled": True, "slack_channel": "#alerts"},
+            slack_notify=["#other"],
+        )
+
+
+def test_env_overrides_parse():
+    schedule = _schedule(env_overrides=[{"key": "FOO", "value": "bar"}])
+    assert schedule.env_overrides is not None
+    assert schedule.env_overrides[0].key == "FOO"
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [("true", True), ("1", True), ("yes", True), ("", False), ("false", False)],
+)
+def test_is_internal_mode(monkeypatch, value, expected):
+    monkeypatch.setenv("PARADIME_INTERNAL_MODE", value)
+    assert internal_transport.is_internal_mode() is expected


### PR DESCRIPTION
## Summary
This PR consolidates the `paradime bolt verify` command to support both external (GraphQL-backed) and internal (REST-backed) transport modes, adds Slack ID verification, and introduces new schedule configuration fields (`self_healing` and `env_overrides`).

## Key Changes

- **Internal Transport Mode**: Added `paradime/core/bolt/internal_transport.py` to support running `bolt verify` inside the Paradime cluster using company-scoped internal REST endpoints instead of the public GraphQL API. This is selected automatically when `PARADIME_INTERNAL_MODE` is set.

- **Slack ID Verification**: Integrated Slack ID verification into the schedule validation pipeline. The `verify_single_schedule()` function now accepts an optional `slack_id_verifier` callback to check that Slack notification IDs are reachable by the Paradime Slack bot.

- **Command Allow-list**: Added validation to ensure schedule commands start with allowed commands (dbt, re_data, edr, lightdash, python). The list is configurable via the `BOLT_ALLOWED_COMMANDS` environment variable.

- **New Schedule Fields**: 
  - `SelfHealingConfig`: Configuration for self-healing with Slack channel and agent name
  - `EnvOverride`: Environment variable overrides for schedules
  - Added validation to ensure `self_healing.slack_channel` appears in the schedule's notification channels

- **Unified Verify Logic**: Refactored `verify()` command in `paradime/cli/bolt.py` to extract core logic into `run_bolt_verify()` function that works with both transport modes. The transport selection is automatic based on `PARADIME_INTERNAL_MODE`.

- **Comprehensive Tests**: Added `tests/test_bolt_verify.py` with unit tests covering command allow-list validation, Slack verification, environment variable overrides, and internal mode detection.

## Implementation Details

- The internal transport gracefully degrades: if backend endpoints are unreachable, verification continues with reduced functionality rather than failing
- Slack verification is optional and only performed when a verifier is provided (external mode has no verifier)
- The command allow-list can be overridden via environment variable for feature flag support
- Version bumped to 5.10.0

https://claude.ai/code/session_01XVZj4M1uFkVqz9gxknk3YK