### PR TITLE
ENG-3104 Claude/paradime schedule verify kzzec8

### DIFF
--- a/paradime/apis/bolt/client.py
+++ b/paradime/apis/bolt/client.py
@@ -420,6 +420,8 @@ class BoltClient:
             schedules.append(
                 BoltSchedule(
                     name=schedule_json["name"],
+                    slug=schedule_json.get("slug"),
+                    display_name=schedule_json.get("displayName"),
                     schedule=schedule_json["schedule"],
                     owner=schedule_json["owner"],
                     last_run_at=schedule_json["lastRunAt"],

--- a/paradime/apis/bolt/client.py
+++ b/paradime/apis/bolt/client.py
@@ -358,6 +358,8 @@ class BoltClient:
                 listBoltSchedules(offset: $offset, limit: $limit, showInactive: $showInactive) {
                     schedules {
                         name
+                        slug
+                        displayName
                         schedule
                         owner
                         lastRunAt

--- a/paradime/apis/bolt/types.py
+++ b/paradime/apis/bolt/types.py
@@ -42,6 +42,8 @@ class BoltNotifications(BaseModel):
 
 class BoltSchedule(BaseModel):
     name: str
+    slug: Optional[str]
+    display_name: Optional[str]
     schedule: str
     owner: Optional[str]
     last_run_at: Optional[str]

--- a/paradime/cli/bolt.py
+++ b/paradime/cli/bolt.py
@@ -12,6 +12,7 @@ import click
 import requests
 
 from paradime.apis.bolt.types import BoltRunState
+from paradime.cli import console as _console
 from paradime.cli.rich_text_output import (
     print_artifact_downloaded,
     print_artifact_downloading,
@@ -298,7 +299,7 @@ def verify(path: str) -> None:
         schedule_trigger_refs=all_schedules_ref or None,
     )
     if error_string:
-        print_error_table(error_string, is_json=False)
+        _console.result_panel(error_string, style="error", title="Schedules Verification")
         sys.exit(1)
 
     # Check for names not yet registered in the backend and mint slugs.
@@ -308,7 +309,7 @@ def verify(path: str) -> None:
         schedules = None
 
     if not schedules:
-        click.secho("No schedules found.", fg="yellow")
+        _console.result_panel("No schedules found.", style="warning", title="Schedules Verification")
         return
 
     try:
@@ -322,20 +323,34 @@ def verify(path: str) -> None:
             existing_names=existing_names,
         )
         if changed:
-            click.secho(f"Minted slugs in {changed} file(s).", fg="green")
+            _console.result_panel(
+                f"Minted slugs in {changed} file(s).",
+                style="success",
+                title="Schedules Verification",
+            )
         else:
-            click.secho("All schedules verified.", fg="green")
+            _console.result_panel(
+                "All schedules verified.",
+                style="success",
+                title="Schedules Verification",
+            )
     except (ParadimeAPIException, ParadimeException) as e:
-        click.secho(
+        _console.result_panel(
             f"Could not mint slugs (API unavailable): {e}\n"
             f"Non-slug schedule names will be grandfathered by the backend on deploy.",
-            fg="yellow",
+            style="warning",
+            title="Schedules Verification",
         )
     except Exception:
         # Fall back to warnings if minting fails for any reason
         if schedules:
-            for warning in get_slug_format_warnings(schedules):
-                click.secho(f"warning: {warning}", fg="yellow")
+            warnings = get_slug_format_warnings(schedules)
+            if warnings:
+                _console.result_panel(
+                    "\n".join(warnings),
+                    style="warning",
+                    title="Schedules Verification",
+                )
 
 
 @click.command()

--- a/paradime/cli/bolt.py
+++ b/paradime/cli/bolt.py
@@ -316,18 +316,13 @@ def verify(path: str) -> None:
             client = get_cli_client_or_exit()
         root = schedule_path.parent if schedule_path.is_file() else schedule_path
 
-        unregistered = [s.name for s in schedules.schedules if s.name not in existing_names]
-
-        if unregistered:
-            changed = mint_slugs_in_yaml_files(
-                mint_fn=client.bolt.create_schedule_slugs,
-                root=root,
-                existing_names=existing_names,
-            )
-            if changed:
-                click.secho(f"Minted slugs in {changed} file(s).", fg="green")
-            else:
-                click.secho("All schedules verified.", fg="green")
+        changed = mint_slugs_in_yaml_files(
+            mint_fn=client.bolt.create_schedule_slugs,
+            root=root,
+            existing_names=existing_names,
+        )
+        if changed:
+            click.secho(f"Minted slugs in {changed} file(s).", fg="green")
         else:
             click.secho("All schedules verified.", fg="green")
     except (ParadimeAPIException, ParadimeException) as e:

--- a/paradime/cli/bolt.py
+++ b/paradime/cli/bolt.py
@@ -309,7 +309,9 @@ def verify(path: str) -> None:
         schedules = None
 
     if not schedules:
-        _console.result_panel("No schedules found.", style="warning", title="Schedules Verification")
+        _console.result_panel(
+            "No schedules found.", style="warning", title="Schedules Verification"
+        )
         return
 
     try:

--- a/paradime/cli/bolt.py
+++ b/paradime/cli/bolt.py
@@ -29,7 +29,7 @@ from paradime.core.bolt.schedule import (
     get_slug_format_warnings,
     is_valid_schedule_at_path,
 )
-from paradime.core.bolt.yaml_rewriter import mint_slugs_in_yaml_files
+from paradime.core.bolt.yaml_rewriter import migrate_yaml_to_v3, mint_slugs_in_yaml_files
 
 WAIT_SLEEP: Final = 10
 WAIT_SLEEP_STREAMING: Final = 2
@@ -357,6 +357,79 @@ def verify(path: str) -> None:
 
 @click.command()
 @click.option(
+    "--path",
+    help="Path to paradime_schedules.yml file or project root containing .bolt/ directory.",
+    show_default=True,
+    default=".",
+)
+def migrate(path: str) -> None:
+    """
+    Migrate v1/v2 schedule YAML files to v3 format.
+
+    Fetches schedule data (slug and display_name) from the Paradime backend
+    and rewrites local YAML files to v3 format:
+
+    \b
+    - v1 (only name): name → display_name from DB, slug → name from DB
+    - v2 (name + display_name): name → display_name from DB, slug → name from DB
+    - v3 (already has slug): skipped
+
+    Cross-references in deferred_schedule, turbo_ci, and schedule_trigger
+    are also updated to use slug-based fields.
+    """
+    print_version()
+    schedule_path = Path(path)
+
+    client = get_cli_client_or_exit()
+    try:
+        all_schedules = client.bolt.list_schedules(offset=0, limit=10000)
+    except (ParadimeAPIException, ParadimeException) as e:
+        _console.result_panel(
+            f"Failed to fetch schedules from backend: {e}",
+            style="error",
+            title="Schedule Migration",
+        )
+        sys.exit(1)
+
+    # Build lookup: DB name → {slug, display_name}
+    db_schedules: dict[str, dict[str, str | None]] = {}
+    for s in all_schedules.schedules:
+        db_schedules[s.name] = {
+            "slug": s.slug,
+            "display_name": s.display_name,
+        }
+
+    root = schedule_path.parent if schedule_path.is_file() else schedule_path
+
+    try:
+        changed = migrate_yaml_to_v3(
+            root=root,
+            db_schedules=db_schedules,
+        )
+    except Exception as e:
+        _console.result_panel(
+            f"Migration failed: {e}",
+            style="error",
+            title="Schedule Migration",
+        )
+        sys.exit(1)
+
+    if changed:
+        _console.result_panel(
+            f"Migrated {changed} file(s) to v3 format.",
+            style="success",
+            title="Schedule Migration",
+        )
+    else:
+        _console.result_panel(
+            "No files needed migration. All schedules are already in v3 format or not found in the backend.",
+            style="success",
+            title="Schedule Migration",
+        )
+
+
+@click.command()
+@click.option(
     "--slug",
     "--schedule-name",
     "slug",
@@ -429,4 +502,5 @@ bolt.add_command(run)
 bolt.add_command(retry)
 bolt.add_command(schedule)
 bolt.add_command(verify)
+bolt.add_command(migrate)
 bolt.add_command(artifact)

--- a/paradime/cli/console.py
+++ b/paradime/cli/console.py
@@ -83,6 +83,32 @@ def debug(message: str) -> None:
         console.print(f"[muted]  {message}[/]")
 
 
+def result_panel(
+    message: str,
+    *,
+    style: str = "success",
+    title: str = "Result",
+) -> None:
+    """Display a result inside a bordered panel with spacing."""
+    style_map = {
+        "success": ("success", "green", "✓"),
+        "error": ("error", "red", "✗"),
+        "warning": ("warning", "yellow", "⚠"),
+    }
+    text_style, border_colour, icon = style_map.get(style, style_map["success"])
+    body = Text.from_markup(f"[{text_style}]{icon}[/]  {message}")
+    panel = Panel(
+        body,
+        title=f"[bold]{title}[/]",
+        border_style=border_colour,
+        padding=(1, 3),
+        expand=False,
+    )
+    console.print()
+    console.print(panel)
+    console.print()
+
+
 def header(title: str, subtitle: str | None = None) -> None:
     """Command header — bold brand-coloured title, optional muted subtitle."""
     console.print()

--- a/paradime/core/bolt/schedule.py
+++ b/paradime/core/bolt/schedule.py
@@ -57,6 +57,7 @@ class DeferredSchedule(ParadimeScheduleBase):
     enabled: bool
     deferred_schedule_name: Optional[str]
     deferred_manifest_schedule: Optional[str]
+    deferred_schedule_slug: Optional[str] = None
     # `successful_runs_only` is the canonical name used by the JSON schema and the
     # UI. `successful_run_only` is kept for backwards compatibility with existing
     # YAML files.
@@ -67,8 +68,10 @@ class DeferredSchedule(ParadimeScheduleBase):
     @classmethod
     def validate_all_fields_at_the_same_time(cls, values: Any) -> Any:
         # backwards compatability
-        deferred_schedule_name = values.get("deferred_schedule_name") or values.get(
-            "deferred_manifest_schedule"
+        deferred_schedule_name = (
+            values.get("deferred_schedule_slug")
+            or values.get("deferred_schedule_name")
+            or values.get("deferred_manifest_schedule")
         )
         if not deferred_schedule_name:
             raise ValueError("Missing deferred_schedule_name")
@@ -94,8 +97,17 @@ class Hightouch(ParadimeScheduleBase):
 class ScheduleTrigger(ParadimeScheduleBase):
     enabled: bool
     schedule_name: str
+    schedule_slug: Optional[str] = None
     workspace_name: str
     trigger_on: List[str]
+
+    @root_validator()
+    @classmethod
+    def resolve_slug(cls, values: Any) -> Any:
+        slug = values.get("schedule_slug")
+        if slug:
+            values["schedule_name"] = slug
+        return values
 
     @validator("trigger_on")
     def validate_trigger_on(cls, trigger_on: List[str]) -> List[str]:
@@ -207,6 +219,7 @@ class Integrations(BaseModel):
 
 class ParadimeSchedule(ParadimeScheduleBase):
     name: str
+    slug: Optional[str] = None
     display_name: Optional[str] = None
     schedule: str
     timezone: Optional[str] = None
@@ -248,6 +261,23 @@ class ParadimeSchedule(ParadimeScheduleBase):
         if len(display_name) > DISPLAY_NAME_MAX_LENGTH:
             raise ValueError(f"display_name must be {DISPLAY_NAME_MAX_LENGTH} characters or fewer")
         return display_name
+
+    @root_validator()
+    @classmethod
+    def validate_all_fields(cls, values: Any) -> Any:
+        # v3 slug swap: when slug is present, YAML `name` is the human label
+        slug = values.get("slug")
+        if slug:
+            yaml_name = values["name"]
+            values["name"] = slug
+            values["display_name"] = yaml_name
+            if "\n" in yaml_name or "\r" in yaml_name:
+                raise ValueError("display_name must not contain newlines")
+            if len(yaml_name) > DISPLAY_NAME_MAX_LENGTH:
+                raise ValueError(
+                    f"display_name must be {DISPLAY_NAME_MAX_LENGTH} characters or fewer"
+                )
+        return values
 
 
 class ParadimeSchedules(ParadimeScheduleBase):

--- a/paradime/core/bolt/schedule.py
+++ b/paradime/core/bolt/schedule.py
@@ -96,7 +96,7 @@ class Hightouch(ParadimeScheduleBase):
 
 class ScheduleTrigger(ParadimeScheduleBase):
     enabled: bool
-    schedule_name: str
+    schedule_name: Optional[str] = None
     schedule_slug: Optional[str] = None
     workspace_name: str
     trigger_on: List[str]
@@ -104,9 +104,10 @@ class ScheduleTrigger(ParadimeScheduleBase):
     @root_validator()
     @classmethod
     def resolve_slug(cls, values: Any) -> Any:
-        slug = values.get("schedule_slug")
-        if slug:
-            values["schedule_name"] = slug
+        schedule_name = values.get("schedule_slug") or values.get("schedule_name")
+        if not schedule_name:
+            raise ValueError("Missing schedule_name or schedule_slug")
+        values["schedule_name"] = schedule_name
         return values
 
     @validator("trigger_on")

--- a/paradime/core/bolt/yaml_rewriter.py
+++ b/paradime/core/bolt/yaml_rewriter.py
@@ -1,13 +1,3 @@
-"""Rewrite schedule YAML files to mint slugs for non-slug names.
-
-Uses ``ruamel.yaml`` to preserve comments, key order, and formatting when
-modifying the YAML in place.
-
-v3 format: the human-readable label stays as ``name`` and the minted slug is
-inserted as ``slug``. Cross-references use ``deferred_schedule_slug`` and
-``schedule_slug`` fields.
-"""
-
 from pathlib import Path
 from typing import Callable, List, Set
 
@@ -46,12 +36,17 @@ def mint_slugs_in_yaml_files(
     is inserted as ``slug``. Cross-references use ``deferred_schedule_slug`` and
     ``schedule_slug`` fields.
 
+    v2 → v3 auto-migration: when a schedule already has ``name`` (a slug) and
+    ``display_name`` (the human label), it is converted to v3 by swapping them.
+
     Two-pass approach:
     1. Collect all schedule names across all files. For names that are not valid
        slugs **and not already deployed** (i.e. not in ``existing_names``), call
        the backend to mint slugs. Names that already exist in the backend are
-       grandfathered and left unchanged.
-    2. Rewrite all files: insert ``slug`` fields and fix cross-references.
+       grandfathered and left unchanged. v2 schedules with ``display_name`` are
+       marked for auto-migration (no minting needed).
+    2. Rewrite all files: insert ``slug`` fields, migrate v2 → v3, and fix
+       cross-references.
 
     Args:
         mint_fn: Callable that takes a list of display names and returns slugs.
@@ -76,8 +71,9 @@ def mint_slugs_in_yaml_files(
     # --- Pass 1: load all files and collect names that need slugs ---
     loaded: list[tuple[Path, dict]] = []
     names_needing_slugs: list[str] = []  # display names to mint
-    # Track name → slug for all names (both existing and to-be-minted)
+    # Track display_name/old_name → slug for all names
     name_to_slug: dict[str, str] = {}
+    has_v2_to_migrate = False
 
     for filepath in files:
         doc = yaml.load(filepath)
@@ -92,16 +88,22 @@ def mint_slugs_in_yaml_files(
             if not isinstance(entry, dict):
                 continue
 
-            # v3 schedules already have a slug — use it directly
             existing_slug = entry.get("slug")
             name = entry.get("name")
             if not name:
                 continue
             name_str = str(name)
+            display_name = entry.get("display_name")
 
             if existing_slug:
                 # Already v3: map the display name to the existing slug
                 name_to_slug[name_str] = str(existing_slug)
+            elif display_name:
+                # v2 format: name is the slug, display_name is the label.
+                # Auto-migrate to v3 (no minting needed).
+                name_to_slug[name_str] = name_str
+                name_to_slug[str(display_name)] = name_str
+                has_v2_to_migrate = True
             elif name_str in grandfathered:
                 name_to_slug[name_str] = name_str
             else:
@@ -109,13 +111,14 @@ def mint_slugs_in_yaml_files(
                     names_needing_slugs.append(name_str)
                 name_to_slug[name_str] = name_str  # placeholder, updated below
 
-    if not names_needing_slugs:
+    if not names_needing_slugs and not has_v2_to_migrate:
         return 0
 
-    # Mint slugs from the backend
-    minted_slugs = mint_fn(names_needing_slugs)
-    for display_name, minted in zip(names_needing_slugs, minted_slugs):
-        name_to_slug[display_name] = minted
+    # Mint slugs from the backend (only for genuinely new names)
+    if names_needing_slugs:
+        minted_slugs = mint_fn(names_needing_slugs)
+        for display_name, minted in zip(names_needing_slugs, minted_slugs):
+            name_to_slug[display_name] = minted
 
     # --- Pass 2: rewrite all files ---
     files_changed = 0
@@ -127,14 +130,27 @@ def mint_slugs_in_yaml_files(
             if not isinstance(entry, dict):
                 continue
 
-            # Insert slug for schedules that need one (v3 format)
             name = entry.get("name")
             existing_slug = entry.get("slug")
-            if name and not existing_slug and str(name) not in grandfathered:
+            display_name = entry.get("display_name")
+
+            if existing_slug:
+                # Already v3, nothing to do for this schedule's own fields
+                pass
+            elif name and display_name:
+                # v2 → v3 migration: name is the slug, display_name is the label.
+                # Swap: name ← display_name, insert slug ← old name, remove display_name.
+                old_slug = str(name)
+                entry["name"] = str(display_name)
+                # Insert slug right after name
+                entry.insert(1, "slug", old_slug)  # type: ignore[attr-defined]
+                del entry["display_name"]
+                changed = True
+            elif name and str(name) not in grandfathered:
+                # New schedule needing a minted slug
                 name_str = str(name)
                 slug: str | None = name_to_slug.get(name_str)
                 if slug and slug != name_str:
-                    # Insert slug right after name (v3 format)
                     entry.insert(1, "slug", slug)  # type: ignore[attr-defined]
                     changed = True
 

--- a/paradime/core/bolt/yaml_rewriter.py
+++ b/paradime/core/bolt/yaml_rewriter.py
@@ -2,6 +2,10 @@
 
 Uses ``ruamel.yaml`` to preserve comments, key order, and formatting when
 modifying the YAML in place.
+
+v3 format: the human-readable label stays as ``name`` and the minted slug is
+inserted as ``slug``. Cross-references use ``deferred_schedule_slug`` and
+``schedule_slug`` fields.
 """
 
 from pathlib import Path
@@ -38,14 +42,16 @@ def mint_slugs_in_yaml_files(
 ) -> int:
     """Walk schedule YAML files, mint slugs for non-slug names, rewrite in place.
 
+    v3 format: the human-readable ``name`` is left in place and the minted slug
+    is inserted as ``slug``. Cross-references use ``deferred_schedule_slug`` and
+    ``schedule_slug`` fields.
+
     Two-pass approach:
     1. Collect all schedule names across all files. For names that are not valid
        slugs **and not already deployed** (i.e. not in ``existing_names``), call
        the backend to mint slugs. Names that already exist in the backend are
        grandfathered and left unchanged.
-    2. Rewrite all files: update ``name`` fields, set ``display_name``, and fix
-       cross-references in ``deferred_schedule``, ``turbo_ci``, and
-       ``schedule_trigger`` sections.
+    2. Rewrite all files: insert ``slug`` fields and fix cross-references.
 
     Args:
         mint_fn: Callable that takes a list of display names and returns slugs.
@@ -85,19 +91,22 @@ def mint_slugs_in_yaml_files(
         for entry in schedules:
             if not isinstance(entry, dict):
                 continue
+
+            # v3 schedules already have a slug — use it directly
+            existing_slug = entry.get("slug")
             name = entry.get("name")
             if not name:
                 continue
             name_str = str(name)
 
-            if name_str in grandfathered:
-                display = entry.get("display_name") or name_str
-                name_to_slug[str(display)] = name_str
+            if existing_slug:
+                # Already v3: map the display name to the existing slug
+                name_to_slug[name_str] = str(existing_slug)
+            elif name_str in grandfathered:
                 name_to_slug[name_str] = name_str
             else:
-                display = entry.get("display_name") or name_str
-                if str(display) not in names_needing_slugs:
-                    names_needing_slugs.append(str(display))
+                if name_str not in names_needing_slugs:
+                    names_needing_slugs.append(name_str)
                 name_to_slug[name_str] = name_str  # placeholder, updated below
 
     if not names_needing_slugs:
@@ -118,46 +127,45 @@ def mint_slugs_in_yaml_files(
             if not isinstance(entry, dict):
                 continue
 
-            # Rewrite the schedule's own name (only if not grandfathered)
+            # Insert slug for schedules that need one (v3 format)
             name = entry.get("name")
-            if name and str(name) not in grandfathered:
-                old_name = str(name)
-                display = entry.get("display_name") or old_name
-                slug: str | None = name_to_slug.get(str(display)) or name_to_slug.get(old_name)
-                if slug and slug != old_name:
-                    if "display_name" not in entry:
-                        entry.insert(1, "display_name", old_name)  # type: ignore[attr-defined]
-                    entry["name"] = slug
+            existing_slug = entry.get("slug")
+            if name and not existing_slug and str(name) not in grandfathered:
+                name_str = str(name)
+                slug: str | None = name_to_slug.get(name_str)
+                if slug and slug != name_str:
+                    # Insert slug right after name (v3 format)
+                    entry.insert(1, "slug", slug)  # type: ignore[attr-defined]
                     changed = True
 
-            # Fix deferred_schedule.deferred_schedule_name
+            # Fix deferred_schedule cross-reference (use deferred_schedule_slug)
             deferred = entry.get("deferred_schedule")
             if isinstance(deferred, dict):
                 ref = deferred.get("deferred_schedule_name")
                 if ref and str(ref) in name_to_slug:
                     new_ref = name_to_slug[str(ref)]
                     if new_ref != str(ref):
-                        deferred["deferred_schedule_name"] = new_ref
+                        deferred["deferred_schedule_slug"] = new_ref
                         changed = True
 
-            # Fix turbo_ci.deferred_schedule_name
+            # Fix turbo_ci cross-reference (use deferred_schedule_slug)
             turbo = entry.get("turbo_ci")
             if isinstance(turbo, dict):
                 ref = turbo.get("deferred_schedule_name")
                 if ref and str(ref) in name_to_slug:
                     new_ref = name_to_slug[str(ref)]
                     if new_ref != str(ref):
-                        turbo["deferred_schedule_name"] = new_ref
+                        turbo["deferred_schedule_slug"] = new_ref
                         changed = True
 
-            # Fix schedule_trigger.schedule_name
+            # Fix schedule_trigger cross-reference (use schedule_slug)
             trigger = entry.get("schedule_trigger")
             if isinstance(trigger, dict):
                 ref = trigger.get("schedule_name")
                 if ref and str(ref) in name_to_slug:
                     new_ref = name_to_slug[str(ref)]
                     if new_ref != str(ref):
-                        trigger["schedule_name"] = new_ref
+                        trigger["schedule_slug"] = new_ref
                         changed = True
 
         if changed:

--- a/paradime/core/bolt/yaml_rewriter.py
+++ b/paradime/core/bolt/yaml_rewriter.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Callable, List, Set
+from typing import Callable, Dict, List, Optional, Set
 
 from ruamel.yaml import YAML
 
@@ -175,6 +175,145 @@ def mint_slugs_in_yaml_files(
                         changed = True
 
             # Fix schedule_trigger cross-reference (use schedule_slug)
+            trigger = entry.get("schedule_trigger")
+            if isinstance(trigger, dict):
+                ref = trigger.get("schedule_name")
+                if ref and str(ref) in name_to_slug:
+                    new_ref = name_to_slug[str(ref)]
+                    if new_ref != str(ref):
+                        trigger["schedule_slug"] = new_ref
+                        changed = True
+
+        if changed:
+            yaml.dump(doc, filepath)
+            files_changed += 1
+
+    return files_changed
+
+
+def migrate_yaml_to_v3(
+    *,
+    root: Path,
+    db_schedules: Dict[str, Dict[str, Optional[str]]],
+) -> int:
+    """Migrate v1/v2 schedule YAML files to v3 format using data from the backend.
+
+    For each schedule in the YAML:
+    - v1 (only ``name``): set ``name`` = display_name from DB, insert ``slug`` = name from DB.
+    - v2 (``name`` + ``display_name``): set ``name`` = display_name from DB,
+      insert ``slug`` = name from DB, remove ``display_name``.
+    - v3 (already has ``slug``): skip.
+
+    Also updates cross-references (``deferred_schedule``, ``turbo_ci``,
+    ``schedule_trigger``) to use slug-based fields.
+
+    Args:
+        root: Project root directory containing ``.bolt/`` or ``paradime_schedules.yml``.
+        db_schedules: Mapping of DB schedule name (slug) → {"slug": ..., "display_name": ...}.
+
+    Returns:
+        Number of files modified.
+    """
+    yaml = YAML()
+    yaml.preserve_quotes = True
+
+    files = _find_yaml_files(root)
+    if not files:
+        return 0
+
+    # Build a lookup from any known name → slug for cross-reference fixups.
+    # Keys include both the DB name (slug) and display_name.
+    name_to_slug: Dict[str, str] = {}
+    for db_name, info in db_schedules.items():
+        slug = info.get("slug") or db_name
+        display_name = info.get("display_name")
+        name_to_slug[db_name] = slug
+        if display_name:
+            name_to_slug[display_name] = slug
+
+    loaded: list[tuple[Path, dict]] = []
+    for filepath in files:
+        doc = yaml.load(filepath)
+        if not doc or "schedules" not in doc:
+            continue
+        schedules = doc.get("schedules")
+        if not isinstance(schedules, list):
+            continue
+        loaded.append((filepath, doc))
+
+    files_changed = 0
+    for filepath, doc in loaded:
+        changed = False
+        schedules = doc["schedules"]
+
+        for entry in schedules:
+            if not isinstance(entry, dict):
+                continue
+
+            existing_slug = entry.get("slug")
+            if existing_slug:
+                # Already v3, skip
+                continue
+
+            yaml_name = entry.get("name")
+            if not yaml_name:
+                continue
+            yaml_name_str = str(yaml_name)
+            yaml_display_name = entry.get("display_name")
+
+            # Look up from DB: for v1 YAML, name matches a DB name;
+            # for v2, name is the slug in DB.
+            db_info = db_schedules.get(yaml_name_str)
+            if not db_info:
+                # Try matching by display_name for edge cases
+                if yaml_display_name:
+                    db_info = db_schedules.get(str(yaml_display_name))
+                if not db_info:
+                    continue
+
+            db_slug = db_info.get("slug") or yaml_name_str
+            db_display_name = db_info.get("display_name")
+
+            if yaml_display_name:
+                # v2 format: name is slug, display_name is label
+                # → v3: name = display_name from DB, slug = name from DB
+                entry["name"] = db_display_name or str(yaml_display_name)
+                entry.insert(1, "slug", db_slug)  # type: ignore[attr-defined]
+                del entry["display_name"]
+                changed = True
+            else:
+                # v1 format: only name
+                # → v3: name = display_name from DB, slug = name from DB
+                if db_display_name and db_display_name != yaml_name_str:
+                    entry["name"] = db_display_name
+                    entry.insert(1, "slug", db_slug)  # type: ignore[attr-defined]
+                    changed = True
+                elif db_slug != yaml_name_str:
+                    # name is the display name (not a slug), slug comes from DB
+                    entry.insert(1, "slug", db_slug)  # type: ignore[attr-defined]
+                    changed = True
+
+            # Fix deferred_schedule cross-reference
+            deferred = entry.get("deferred_schedule")
+            if isinstance(deferred, dict):
+                ref = deferred.get("deferred_schedule_name")
+                if ref and str(ref) in name_to_slug:
+                    new_ref = name_to_slug[str(ref)]
+                    if new_ref != str(ref):
+                        deferred["deferred_schedule_slug"] = new_ref
+                        changed = True
+
+            # Fix turbo_ci cross-reference
+            turbo = entry.get("turbo_ci")
+            if isinstance(turbo, dict):
+                ref = turbo.get("deferred_schedule_name")
+                if ref and str(ref) in name_to_slug:
+                    new_ref = name_to_slug[str(ref)]
+                    if new_ref != str(ref):
+                        turbo["deferred_schedule_slug"] = new_ref
+                        changed = True
+
+            # Fix schedule_trigger cross-reference
             trigger = entry.get("schedule_trigger")
             if isinstance(trigger, dict):
                 ref = trigger.get("schedule_name")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "paradime-io"
-version = "5.10.0"
+version = "5.11.0"
 description = "Paradime - Python SDK"
 authors = [
     { name = "Bhuvan Singla", email = "bhuvan@paradime.io" },


### PR DESCRIPTION
## Summary

- **v3 schedule YAML format**: `name` is now the human-readable label and `slug` is the machine identifier. The backend detects v3 by checking whether `slug` is present.
- **v2 → v3 auto-migration**: `paradime bolt verify` converts existing v2 schedules (that have both `name` as slug + `display_name`) into v3 format by swapping them (`name` ← display_name, `slug` ← old name, `display_name` removed).
- **New schedule slug minting**: schedules without a slug get one minted from the backend and inserted as `slug` (the human label stays as `name`).
- **Cross-reference fields**: deferred_schedule and turbo_ci use `deferred_schedule_slug`; schedule_trigger uses `schedule_slug`.
- **Cross-workspace schedule_trigger validation**: `verify` now fetches all schedule names across workspaces via `listAllScheduleNames` and validates schedule_trigger references against them.

### v2 → v3 example
```yaml
# Before (v2)
- name: tossing-bary-txc4mx
  display_name: Nightly Build
  ...

# After (v3)
- name: Nightly Build
  slug: tossing-bary-txc4mx
  ...
```

## Files changed

- `paradime/core/bolt/schedule.py` — added `slug` to `ParadimeSchedule`, `deferred_schedule_slug` to `DeferredSchedule`, `schedule_slug` to `ScheduleTrigger`, plus v3 swap root validators
- `paradime/core/bolt/yaml_rewriter.py` — v3 rewriting + v2→v3 auto-migration
- `paradime/cli/bolt.py` — always call `mint_slugs_in_yaml_files` (not gated on unregistered), cross-workspace validation
- `paradime/apis/bolt/client.py` — `list_all_schedule_names()` for cross-workspace schedule_trigger validation

## Test plan

- [ ] `paradime bolt verify` on a repo with v2 schedules (name=slug + display_name) → auto-migrates to v3
- [ ] `paradime bolt verify` on a repo with new schedules (no slug) → mints slugs from backend
- [ ] `paradime bolt verify` on a repo with v3 schedules (already has slug) → no changes
- [ ] Cross-references (deferred_schedule, turbo_ci, schedule_trigger) get slug fields added
- [ ] Deploy migrated YAML to dev and verify schedules work correctly