### PR TITLE
feat(integrations): add DataHub push integration for dbt artifacts

### DIFF
--- a/paradime/cli/integrations/datahub.py
+++ b/paradime/cli/integrations/datahub.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import sys
+from typing import Optional
+
+import click
+
+from paradime.cli import console
+from paradime.cli.utils import env_click_option
+from paradime.core.scripts.datahub import push_artifacts_to_datahub
+
+
+@click.command(context_settings=dict(max_content_width=160))
+@env_click_option(
+    "datahub-server",
+    "DATAHUB_GMS_URL",
+    help="The DataHub GMS server URL (e.g. https://<instance>.acryl.io/gms).",
+)
+@env_click_option(
+    "datahub-token",
+    "DATAHUB_GMS_TOKEN",
+    help="The DataHub personal access token used to authenticate to GMS. "
+    "Required for DataHub Cloud / auth-enabled instances; omit for a local instance "
+    "with metadata service auth disabled.",
+    required=False,
+)
+@env_click_option(
+    "target-platform",
+    "DATAHUB_TARGET_PLATFORM",
+    help="The data warehouse platform the dbt models run on (e.g. snowflake, bigquery, redshift).",
+)
+@env_click_option(
+    "domain",
+    "DATAHUB_DOMAIN",
+    help="Optional DataHub domain URN to associate the pushed assets with "
+    "(e.g. urn:li:domain:sales).",
+    required=False,
+)
+@env_click_option(
+    "paradime-resources-directory",
+    "PARADIME_RESOURCES_DIRECTORY",
+    help="The directory where the paradime resources are stored.",
+    required=False,
+)
+@click.option("--json", "json_output", is_flag=True, help="Output results as JSON.", default=False)
+def datahub_artifacts_push(
+    datahub_server: str,
+    datahub_token: Optional[str],
+    target_platform: str,
+    domain: Optional[str],
+    paradime_resources_directory: Optional[str],
+    json_output: bool,
+) -> None:
+    """
+    Push Bolt dbt artifacts (manifest + catalog) to DataHub
+    """
+    try:
+        success, found_files = push_artifacts_to_datahub(
+            paradime_resources_directory=paradime_resources_directory or ".",
+            datahub_server=datahub_server,
+            datahub_token=datahub_token,
+            target_platform=target_platform,
+            domain=domain,
+        )
+    except Exception as e:
+        if json_output:
+            console.json_out({"error": str(e), "success": False})
+            sys.exit(1)
+        raise
+
+    if json_output:
+        console.json_out({"success": success, "found_files": found_files})
+        if not success:
+            sys.exit(1)
+        return
+
+    if not success:
+        sys.exit(1)
+
+    if not found_files:
+        console.warning(
+            f"No dbt artifacts found in {paradime_resources_directory or 'current directory'} "
+            "to push to DataHub."
+        )

--- a/paradime/cli/run.py
+++ b/paradime/cli/run.py
@@ -19,6 +19,7 @@ from paradime.cli.integrations.aws_stepfunctions import (
     aws_stepfunctions_trigger,
 )
 from paradime.cli.integrations.census import census_list_syncs, census_sync
+from paradime.cli.integrations.datahub import datahub_artifacts_push
 from paradime.cli.integrations.fivetran import fivetran_list_connectors, fivetran_sync
 from paradime.cli.integrations.gcp_bigquery_transfer import (
     gcp_bigquery_transfer_list,
@@ -95,6 +96,7 @@ run.add_command(adf_list_pipelines)
 run.add_command(hex_trigger)
 run.add_command(hex_list_projects)
 run.add_command(montecarlo_artifacts_import)
+run.add_command(datahub_artifacts_push)
 run.add_command(hightouch_sync)
 run.add_command(hightouch_sync_sequence)
 run.add_command(hightouch_list_syncs)

--- a/paradime/core/scripts/datahub.py
+++ b/paradime/core/scripts/datahub.py
@@ -1,0 +1,156 @@
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any, Dict, Final, Optional, Tuple
+
+import yaml  # type: ignore[import-untyped]
+
+from paradime.cli import console
+
+PARADIME_RESOURCES_DIRECTORY_ENV_VAR: Final = "PARADIME_RESOURCES_DIRECTORY"
+DATAHUB_SERVER_ENV_VAR: Final = "DATAHUB_GMS_URL"
+DATAHUB_TOKEN_ENV_VAR: Final = "DATAHUB_GMS_TOKEN"
+DATAHUB_TARGET_PLATFORM_ENV_VAR: Final = "DATAHUB_TARGET_PLATFORM"
+DATAHUB_DOMAIN_ENV_VAR: Final = "DATAHUB_DOMAIN"
+
+
+def build_datahub_recipe(
+    *,
+    manifest_path: Path,
+    catalog_path: Path,
+    datahub_server: str,
+    datahub_token: Optional[str] = None,
+    target_platform: str,
+    domain: Optional[str] = None,
+) -> Dict[str, Any]:
+    """
+    Build an acryl-datahub ingestion recipe that reads dbt artifacts and emits to
+    DataHub's REST sink (GMS). This reuses DataHub's native ``dbt`` source so the
+    output matches what a dbt Cloud / dbt Core ingestion produces.
+
+    ``datahub_token`` is optional: DataHub Cloud (and any deployment with metadata
+    service auth enabled) requires a personal access token, but a local/self-hosted
+    instance with auth disabled accepts writes without one.
+
+    When ``domain`` is provided, a ``simple_add_dataset_domain`` transformer is added
+    so every emitted dataset is associated with that DataHub domain URN.
+    """
+    sink_config: Dict[str, Any] = {"server": datahub_server}
+    if datahub_token:
+        sink_config["token"] = datahub_token
+
+    recipe: Dict[str, Any] = {
+        "source": {
+            "type": "dbt",
+            "config": {
+                "manifest_path": str(manifest_path),
+                "catalog_path": str(catalog_path),
+                "target_platform": target_platform,
+            },
+        },
+        "sink": {
+            "type": "datahub-rest",
+            "config": sink_config,
+        },
+    }
+
+    if domain:
+        recipe["transformers"] = [
+            {
+                "type": "simple_add_dataset_domain",
+                "config": {
+                    "semantics": "OVERWRITE",
+                    "domains": [domain],
+                },
+            }
+        ]
+
+    return recipe
+
+
+def push_artifacts_to_datahub(
+    *,
+    paradime_resources_directory: str,
+    datahub_server: str,
+    datahub_token: Optional[str] = None,
+    target_platform: str,
+    domain: Optional[str] = None,
+) -> Tuple[bool, bool]:
+    """
+    Search the resources directory for dbt artifacts (``target/manifest.json`` and
+    ``target/catalog.json``) and push them to DataHub for each project found.
+
+    Returns ``(success, found_files)`` mirroring the other artifact-based integrations.
+    """
+    success, found_files = True, False
+    for root, _dirs, _files in os.walk(paradime_resources_directory):
+        # DataHub's dbt source needs both the manifest and the catalog. The catalog is
+        # only produced by `dbt docs generate`, so a manifest without a catalog is skipped.
+        manifest_path = Path(root) / "target" / "manifest.json"
+        catalog_path = Path(root) / "target" / "catalog.json"
+
+        if not manifest_path.is_file():
+            continue
+
+        if not catalog_path.is_file():
+            console.warning(
+                f"Found {manifest_path} but no catalog.json alongside it. "
+                "Run `dbt docs generate` in the schedule so target/catalog.json is produced. Skipping."
+            )
+            continue
+
+        found_files = True
+
+        try:
+            _run_datahub_ingestion(
+                manifest_path=manifest_path,
+                catalog_path=catalog_path,
+                datahub_server=datahub_server,
+                datahub_token=datahub_token,
+                target_platform=target_platform,
+                domain=domain,
+            )
+        except Exception as e:
+            console.error(f"Error pushing artifacts to DataHub: {e!r}")
+            success = False
+
+    return success, found_files
+
+
+def _run_datahub_ingestion(
+    *,
+    manifest_path: Path,
+    catalog_path: Path,
+    datahub_server: str,
+    datahub_token: Optional[str],
+    target_platform: str,
+    domain: Optional[str],
+) -> None:
+    recipe = build_datahub_recipe(
+        manifest_path=manifest_path,
+        catalog_path=catalog_path,
+        datahub_server=datahub_server,
+        datahub_token=datahub_token,
+        target_platform=target_platform,
+        domain=domain,
+    )
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        recipe_path = Path(tmpdir) / "datahub_recipe.yml"
+        recipe_path.write_text(yaml.safe_dump(recipe, sort_keys=False))
+
+        command = ["datahub", "ingest", "-c", str(recipe_path)]
+        try:
+            console.debug(f"Running datahub ingest command: {command!r}")
+            result = subprocess.run(
+                command, check=True, capture_output=True, text=True, env=os.environ
+            )
+            console.debug(f"datahub ingest result: {result.stdout} {result.stderr}")
+        except FileNotFoundError:
+            raise Exception(
+                "The 'datahub' CLI was not found. acryl-datahub must be installed in the "
+                "runtime environment (it is provided by the Paradime dbt base image)."
+            )
+        except subprocess.CalledProcessError as e:
+            raise Exception(f"Error running datahub ingest: {e.stdout!r} {e.stderr!r}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "paradime-io"
-version = "5.9.0"
+version = "5.10.0"
 description = "Paradime - Python SDK"
 authors = [
     { name = "Bhuvan Singla", email = "bhuvan@paradime.io" },

--- a/uv.lock
+++ b/uv.lock
@@ -916,7 +916,7 @@ wheels = [
 
 [[package]]
 name = "paradime-io"
-version = "5.8.0"
+version = "5.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## Summary

Adds a new Bolt integration that pushes dbt artifacts (`manifest.json` + `catalog.json`) from a Paradime Bolt run into DataHub. It lets a DataHub instance ingest Paradime-run dbt metadata the same way it would ingest dbt Core / dbt Cloud — including column schema, lineage and test assertions — by reusing DataHub's own native `dbt` ingestion source.

It follows the existing **Montecarlo** integration pattern: the third-party tool is **not** declared as a dependency — the `datahub` CLI is provided by the Paradime dbt base image, and the integration shells out to it.

## How the CLI works

New command: `paradime run datahub-artifacts-push`

Run it as a step in a Bolt schedule, after dbt has produced its artifacts:

```bash
dbt build
dbt docs generate          # required — produces target/catalog.json
paradime run datahub-artifacts-push
```

Under the hood it:
1. Walks `--paradime-resources-directory` looking for `target/manifest.json` + `target/catalog.json` (a manifest without a catalog is skipped with a warning, since DataHub's dbt source needs both).
2. Builds a DataHub ingestion recipe (native `dbt` source → `datahub-rest` sink), optionally adding a `simple_add_dataset_domain` transformer when a domain is supplied.
3. Writes the recipe to a short-lived temp file and shells out to `datahub ingest -c <recipe>`.

### Flags / environment variables

| Flag | Env var | Required | Default | Description |
|---|---|---|---|---|
| `--datahub-server` | `DATAHUB_GMS_URL` | Yes | — | DataHub GMS URL (e.g. `https://<instance>.acryl.io/gms`, or `http://localhost:8080` locally) |
| `--datahub-token` | `DATAHUB_GMS_TOKEN` | No | — | Personal access token. Required for DataHub Cloud / auth-enabled instances; omit when metadata service auth is disabled |
| `--target-platform` | `DATAHUB_TARGET_PLATFORM` | Yes | — | Warehouse the dbt models run on (`snowflake`, `bigquery`, `redshift`, `databricks`, `duckdb`, …) |
| `--domain` | `DATAHUB_DOMAIN` | No | — | DataHub domain URN to tag the pushed datasets with (e.g. `urn:li:domain:<id>`) |
| `--paradime-resources-directory` | `PARADIME_RESOURCES_DIRECTORY` | No | `.` | Directory to search for the dbt `target/` artifacts |
| `--json` | — | No | off | Emit machine-readable JSON (`{"success": ..., "found_files": ...}`) |

Each flag can be set as a flag or its env var (flag wins). `PARADIME_LOG_LEVEL=debug` prints the ingest command and DataHub output. Typically the values are stored as Paradime environment variables so the token never lives in the schedule YAML.

### Examples

All env vars (typical Bolt usage):

```bash
export DATAHUB_GMS_URL="https://your-instance.acryl.io/gms"
export DATAHUB_GMS_TOKEN="<pat>"
export DATAHUB_TARGET_PLATFORM="snowflake"
export DATAHUB_DOMAIN="urn:li:domain:<id>"   # optional
paradime run datahub-artifacts-push
```

All flags (local instance with auth disabled, no token):

```bash
paradime run datahub-artifacts-push \
  --datahub-server http://localhost:8080 \
  --target-platform snowflake \
  --domain urn:li:domain:<id> \
  --paradime-resources-directory /path/to/dbt/project
```

## Domains

`--domain` attaches a single DataHub domain URN to every dbt dataset in the push, via the `simple_add_dataset_domain` transformer (`semantics: OVERWRITE`). Because each push is already scoped to one project's artifacts, a blanket per-push domain is equivalent to a per-project domain assignment — no URN regex/pattern matching is required.

## Notes

- `acryl-datahub` is **not** added to the SDK's dependencies; the `datahub` CLI is expected to be present in the runtime (provided by the Paradime dbt base image). If it is missing, the command fails with a clear message.
- Only `manifest.json` + `catalog.json` are pushed today. The recipe approach makes it straightforward to add `run_results` / source freshness / model state later.

## Testing

Verified end-to-end against a local DataHub instance: 54 dbt nodes parsed and emitted (datasets with column schema + test assertions), and with `--domain` set, every dbt dataset received the `Domains` aspect for the given URN. Passes `black`, `isort`, `ruff`, `flake8`, and `mypy`.

## Files

- `paradime/core/scripts/datahub.py` *(new)* — recipe builder + `datahub` CLI shell-out
- `paradime/cli/integrations/datahub.py` *(new)* — `datahub-artifacts-push` Click command
- `paradime/cli/run.py` — command registration
- version bump `5.9.0` → `5.10.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
