### PR TITLE
feat(powerbi): add --wait option to wait for dataset refresh completion

### DIFF
--- a/paradime/cli/integrations/power_bi.py
+++ b/paradime/cli/integrations/power_bi.py
@@ -53,6 +53,22 @@ from paradime.core.scripts.power_bi import (
     help="A base64 encoded json string to send as the request body - https://learn.microsoft.com/en-us/power-bi/connect-data/asynchronous-refresh#parameters.",
     required=False,
 )
+@click.option(
+    "--wait/--no-wait",
+    "wait",
+    envvar="POWER_BI_REFRESH_WAIT",
+    default=False,
+    help="Wait for each refresh to complete and report its status, instead of returning "
+    "as soon as the refresh is triggered.\n\n [env: POWER_BI_REFRESH_WAIT]",
+)
+@env_click_option(
+    "timeout-minutes",
+    "POWER_BI_REFRESH_TIMEOUT_MINUTES",
+    help="Maximum minutes to wait per dataset when --wait is set.",
+    required=False,
+    default=60,
+    type=int,
+)
 @click.option("--json", "json_output", is_flag=True, help="Output results as JSON.", default=False)
 def power_bi_refresh(
     tenant_id: str,
@@ -62,6 +78,8 @@ def power_bi_refresh(
     dataset_names: List[str],
     dataset_name: Optional[List[str]],
     refresh_request_body_b64: Optional[str],
+    wait: bool,
+    timeout_minutes: int,
     json_output: bool,
 ) -> None:
     """
@@ -75,21 +93,52 @@ def power_bi_refresh(
         console.header(f"Power BI — Refresh Datasets (group {group_id})")
 
     try:
-        trigger_power_bi_refreshes(
+        results = trigger_power_bi_refreshes(
             client_id=client_id,
             client_secret=client_secret,
             group_id=group_id,
             dataset_names=dataset_names,
             refresh_request_body_b64=refresh_request_body_b64,
             tenant_id=tenant_id,
+            wait=wait,
+            timeout_minutes=timeout_minutes,
         )
-        if json_output:
-            console.json_out({"success": True, "datasets": list(dataset_names)})
     except Exception as e:
         if json_output:
             console.json_out({"error": str(e), "success": False})
             sys.exit(1)
         raise
+
+    failures = [result for result in results if result.is_failure]
+
+    if json_output:
+        console.json_out(
+            {
+                "success": not failures,
+                "datasets": [
+                    {
+                        "dataset": result.dataset_name,
+                        "status": result.status,
+                        "request_id": result.request_id,
+                        "error": result.error,
+                    }
+                    for result in results
+                ],
+            }
+        )
+        if failures:
+            sys.exit(1)
+        return
+
+    for result in results:
+        if result.is_failure:
+            console.error(f"{result.dataset_name}: {result.status} — {result.error}")
+        else:
+            console.success(f"{result.dataset_name}: {result.status}")
+
+    if failures:
+        failed_names = ", ".join(result.dataset_name for result in failures)
+        raise Exception(f"Power BI refresh failed for: {failed_names}")
 
 
 @click.command(context_settings=dict(max_content_width=160))

--- a/paradime/core/scripts/power_bi.py
+++ b/paradime/core/scripts/power_bi.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import base64
 import json
+import time
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from typing import Final, List, Optional
@@ -13,6 +14,7 @@ from paradime.cli import console
 from paradime.core.scripts.utils import handle_http_error
 
 POWER_BI_HOST: Final = "https://api.powerbi.com"
+REFRESH_POLL_INTERVAL_SECONDS: Final = 10
 
 
 @dataclass(frozen=True)
@@ -20,6 +22,20 @@ class Dataset:
     id: str
     name: str
     is_refreshable: bool
+
+
+@dataclass(frozen=True)
+class RefreshResult:
+    dataset_name: str
+    dataset_id: str
+    request_id: Optional[str]
+    # One of: "Triggered" (not waited), "Completed", "Failed", "Disabled", "Timeout"
+    status: str
+    error: Optional[str] = None
+
+    @property
+    def is_failure(self) -> bool:
+        return self.status in ("Failed", "Disabled", "Timeout")
 
 
 def trigger_power_bi_refreshes(
@@ -30,7 +46,17 @@ def trigger_power_bi_refreshes(
     group_id: str,
     dataset_names: List[str],
     refresh_request_body_b64: Optional[str],
-) -> None:
+    wait: bool = False,
+    timeout_minutes: int = 60,
+) -> List[RefreshResult]:
+    """
+    Trigger a Power BI refresh for each named dataset.
+
+    When ``wait`` is False (default), this returns as soon as each refresh has been
+    accepted by Power BI (fire-and-forget). When ``wait`` is True, it polls each
+    dataset's refresh history until the refresh reaches a terminal state or
+    ``timeout_minutes`` elapses, and reports the outcome per dataset.
+    """
     access_token = get_access_token(tenant_id, client_id, client_secret)
 
     datasets = get_power_bi_datasets(
@@ -38,15 +64,15 @@ def trigger_power_bi_refreshes(
         group_id=group_id,
     )
 
-    dataset_ids = set()
+    # Resolve names to ids up front so a bad name fails fast before anything is triggered.
+    targets = []
     for dataset_name in dataset_names:
         if dataset_name not in datasets:
             raise Exception(
                 f"Unable to find dataset: '{dataset_name}' in datasets. Available are: {list(datasets.keys())}"
             )
-        dataset_ids.add(datasets[dataset_name].id)
+        targets.append((dataset_name, datasets[dataset_name].id))
 
-    # Refresh the dataset
     refresh_request_body = None
     if refresh_request_body_b64:
         try:
@@ -54,24 +80,53 @@ def trigger_power_bi_refreshes(
         except Exception as e:
             raise Exception(f"Could not decode refresh body: {e}")
 
-    futures = []
-    with ThreadPoolExecutor() as executor:
-        for dataset_id in dataset_ids:
-            console.debug(f"Refreshing Power BI dataset: {dataset_id}")
-            futures.append(
-                (
-                    dataset_id,
-                    executor.submit(
-                        _refresh_power_bi_dataset,
-                        access_token=access_token,
-                        group_id=group_id,
-                        dataset_id=dataset_id,
-                        refresh_request_body=refresh_request_body,
-                    ),
-                )
+    def _run_one(dataset_name: str, dataset_id: str) -> RefreshResult:
+        console.debug(f"Refreshing Power BI dataset: {dataset_name} ({dataset_id})")
+        try:
+            request_id = _refresh_power_bi_dataset(
+                access_token=access_token,
+                group_id=group_id,
+                dataset_id=dataset_id,
+                refresh_request_body=refresh_request_body,
             )
-        for dataset_id, future in futures:
-            future.result(timeout=60)
+        except Exception as e:
+            return RefreshResult(
+                dataset_name=dataset_name,
+                dataset_id=dataset_id,
+                request_id=None,
+                status="Failed",
+                error=f"Failed to trigger refresh: {e}",
+            )
+
+        if not wait:
+            return RefreshResult(
+                dataset_name=dataset_name,
+                dataset_id=dataset_id,
+                request_id=request_id,
+                status="Triggered",
+            )
+
+        return _wait_for_power_bi_refresh(
+            access_token=access_token,
+            group_id=group_id,
+            dataset_name=dataset_name,
+            dataset_id=dataset_id,
+            request_id=request_id,
+            timeout_minutes=timeout_minutes,
+        )
+
+    # The poll loop enforces the timeout internally; allow a small buffer on the future.
+    future_timeout = (timeout_minutes * 60 + 60) if wait else 60
+
+    results: List[RefreshResult] = []
+    with ThreadPoolExecutor() as executor:
+        futures = [
+            (name, executor.submit(_run_one, name, dataset_id)) for name, dataset_id in targets
+        ]
+        for name, future in futures:
+            results.append(future.result(timeout=future_timeout))
+
+    return results
 
 
 def _refresh_power_bi_dataset(
@@ -80,14 +135,126 @@ def _refresh_power_bi_dataset(
     group_id: str,
     dataset_id: str,
     refresh_request_body: Optional[dict],
-) -> str:
+) -> Optional[str]:
+    """Trigger a refresh and return the Power BI ``RequestId`` of the triggered refresh."""
     refresh_response = requests.post(
         f"{POWER_BI_HOST}/v1.0/myorg/groups/{group_id}/datasets/{dataset_id}/refreshes",
         headers={"Authorization": f"Bearer {access_token}", "Content-Type": "application/json"},
         json=refresh_request_body or {},
     )
     handle_http_error(refresh_response)
-    return refresh_response.text
+    # Power BI returns the id of the triggered refresh in the RequestId response header.
+    return refresh_response.headers.get("RequestId") or refresh_response.headers.get(
+        "x-ms-request-id"
+    )
+
+
+def _wait_for_power_bi_refresh(
+    *,
+    access_token: str,
+    group_id: str,
+    dataset_name: str,
+    dataset_id: str,
+    request_id: Optional[str],
+    timeout_minutes: int,
+) -> RefreshResult:
+    """Poll a dataset's refresh history until the triggered refresh reaches a terminal state."""
+    start_time = time.time()
+    timeout_seconds = timeout_minutes * 60
+    counter = 0
+
+    while True:
+        elapsed = time.time() - start_time
+        if elapsed > timeout_seconds:
+            return RefreshResult(
+                dataset_name=dataset_name,
+                dataset_id=dataset_id,
+                request_id=request_id,
+                status="Timeout",
+                error=f"Refresh did not complete within {timeout_minutes} minutes",
+            )
+
+        try:
+            history_response = requests.get(
+                f"{POWER_BI_HOST}/v1.0/myorg/groups/{group_id}/datasets/{dataset_id}/refreshes?$top=10",
+                headers={
+                    "Authorization": f"Bearer {access_token}",
+                    "Content-Type": "application/json",
+                },
+            )
+            if history_response.status_code != 200:
+                console.debug(
+                    f"[{dataset_name}] Refresh history check returned HTTP "
+                    f"{history_response.status_code}. Retrying."
+                )
+                time.sleep(REFRESH_POLL_INTERVAL_SECONDS)
+                continue
+
+            entries = history_response.json().get("value", [])
+            entry = None
+            if request_id:
+                entry = next((e for e in entries if e.get("requestId") == request_id), None)
+            # Fall back to the most recent refresh if we could not capture the request id.
+            if entry is None and not request_id and entries:
+                entry = entries[0]
+
+            if entry is None:
+                # Refresh not yet visible in history; keep waiting.
+                time.sleep(REFRESH_POLL_INTERVAL_SECONDS)
+                continue
+
+            status = entry.get("status", "Unknown")
+
+            if counter == 0 or counter % 6 == 0:
+                elapsed_min, elapsed_sec = int(elapsed // 60), int(elapsed % 60)
+                console.debug(
+                    f"[{dataset_name}] Refresh status: {status} "
+                    f"({elapsed_min}m {elapsed_sec}s elapsed)"
+                )
+
+            if status == "Completed":
+                return RefreshResult(
+                    dataset_name=dataset_name,
+                    dataset_id=dataset_id,
+                    request_id=request_id,
+                    status="Completed",
+                )
+            if status == "Failed":
+                return RefreshResult(
+                    dataset_name=dataset_name,
+                    dataset_id=dataset_id,
+                    request_id=request_id,
+                    status="Failed",
+                    error=_parse_refresh_error(entry.get("serviceExceptionJson")),
+                )
+            if status == "Disabled":
+                return RefreshResult(
+                    dataset_name=dataset_name,
+                    dataset_id=dataset_id,
+                    request_id=request_id,
+                    status="Disabled",
+                    error="Refresh is disabled for this dataset",
+                )
+
+            # "Unknown" means the refresh is still in progress.
+            counter += 1
+            time.sleep(REFRESH_POLL_INTERVAL_SECONDS)
+
+        except requests.exceptions.RequestException as e:
+            console.debug(f"[{dataset_name}] Network error: {str(e)[:50]}... Retrying.")
+            time.sleep(REFRESH_POLL_INTERVAL_SECONDS)
+            continue
+
+
+def _parse_refresh_error(service_exception_json: Optional[str]) -> str:
+    """Extract a human-readable message from Power BI's serviceExceptionJson, if present."""
+    if not service_exception_json:
+        return "Refresh failed"
+    try:
+        data = json.loads(service_exception_json)
+        return data.get("errorDescription") or data.get("errorCode") or service_exception_json
+    except Exception:
+        return service_exception_json
 
 
 def get_power_bi_datasets(


### PR DESCRIPTION
## Summary

Adds an opt-in **wait-for-completion** mode to `paradime run power-bi-refresh`. Previously the command was fire-and-forget: it triggered Power BI's asynchronous refresh and returned as soon as the request was *accepted* (HTTP 202), without knowing whether the refresh actually succeeded. This made it unsafe to chain downstream steps that depend on freshly refreshed data.

With `--wait`, the command now polls each dataset's refresh history until it reaches a terminal state and reports per-dataset success/failure, exiting non-zero if any refresh fails, is disabled, or times out.

## What changed

**`paradime/core/scripts/power_bi.py`**
- `_refresh_power_bi_dataset` now returns the Power BI `RequestId` (from the trigger response header) so the exact refresh can be tracked.
- New `_wait_for_power_bi_refresh` — polls `GET .../refreshes?$top=10` every 10s, matches the entry by `requestId`, and returns a terminal state (`Completed` / `Failed` / `Disabled` / `Timeout`). Transient HTTP/network errors are logged at debug and retried rather than failing the run (mirrors the Fivetran waiter).
- New `_parse_refresh_error` to surface the message from Power BI's `serviceExceptionJson` on failure.
- New `RefreshResult` dataclass; `trigger_power_bi_refreshes` gained `wait` / `timeout_minutes` and returns `List[RefreshResult]`. Datasets still trigger + poll in parallel, and a per-dataset trigger failure is captured rather than aborting the others.

**`paradime/cli/integrations/power_bi.py`**
- `--wait / --no-wait` → env `POWER_BI_REFRESH_WAIT`, default **off** (backwards compatible).
- `--timeout-minutes` → env `POWER_BI_REFRESH_TIMEOUT_MINUTES`, default **60**.
- Reports per-dataset status (human + `--json`) and exits non-zero on any failure.

## Behavior

- **Default (no `--wait`)**: unchanged fire-and-forget.
- **With `--wait`**: blocks until each dataset's refresh completes, returning a clear success/failure per dataset.

JSON output when waiting:
```json
{"success": false, "datasets": [
  {"dataset": "Sales", "status": "Completed", "request_id": "...", "error": null},
  {"dataset": "Finance", "status": "Failed", "request_id": "...", "error": "<message>"}
]}
```

## Testing

- `black`, `isort`, `mypy`, and `flake8` all clean.
- Verified `--help` surfaces both new options with their env vars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
