### PR TITLE
feat(integrations): standardize --wait/--timeout env vars across all integrations

### DIFF
--- a/paradime/cli/integrations/adf.py
+++ b/paradime/cli/integrations/adf.py
@@ -49,13 +49,15 @@ from paradime.core.scripts.azure_data_factory import list_adf_pipelines, trigger
 )
 @click.option(
     "--wait/--no-wait",
+    envvar="ADF_PIPELINES_WAIT",
     default=True,
-    help="Wait for pipeline runs to complete before returning. Shows progress and final status.",
+    help="Wait for pipeline runs to complete before returning. Shows progress and final status.\n\n [env: ADF_PIPELINES_WAIT]",
 )
 @click.option(
     "--timeout",
     type=int,
-    help="Maximum time to wait in minutes.",
+    envvar="ADF_PIPELINES_TIMEOUT",
+    help="Maximum time to wait in minutes.\n\n [env: ADF_PIPELINES_TIMEOUT]",
     default=1440,
 )
 @click.option("--json", "json_output", is_flag=True, help="Output results as JSON.", default=False)

--- a/paradime/cli/integrations/airbyte.py
+++ b/paradime/cli/integrations/airbyte.py
@@ -58,13 +58,15 @@ from paradime.core.scripts.airbyte import list_airbyte_connections, trigger_airb
 )
 @click.option(
     "--wait/--no-wait",
+    envvar="AIRBYTE_SYNC_WAIT",
     default=True,
-    help="Wait for jobs to complete before returning",
+    help="Wait for jobs to complete before returning\n\n [env: AIRBYTE_SYNC_WAIT]",
 )
 @click.option(
     "--timeout",
     type=int,
-    help="Maximum time to wait in minutes.",
+    envvar="AIRBYTE_SYNC_TIMEOUT",
+    help="Maximum time to wait in minutes.\n\n [env: AIRBYTE_SYNC_TIMEOUT]",
     default=1440,
 )
 @click.option("--json", "json_output", is_flag=True, help="Output results as JSON.", default=False)

--- a/paradime/cli/integrations/airflow.py
+++ b/paradime/cli/integrations/airflow.py
@@ -58,13 +58,15 @@ from paradime.core.scripts.airflow import list_airflow_dags, trigger_airflow_dag
 )
 @click.option(
     "--wait/--no-wait",
-    help="Wait for DAG runs to complete before returning",
+    envvar="AIRFLOW_TRIGGER_WAIT",
+    help="Wait for DAG runs to complete before returning\n\n [env: AIRFLOW_TRIGGER_WAIT]",
     default=True,
 )
 @click.option(
     "--timeout",
     type=int,
-    help="Maximum time to wait in minutes.",
+    envvar="AIRFLOW_TRIGGER_TIMEOUT",
+    help="Maximum time to wait in minutes.\n\n [env: AIRFLOW_TRIGGER_TIMEOUT]",
     default=1440,
 )
 @click.option(

--- a/paradime/cli/integrations/aws_ecs.py
+++ b/paradime/cli/integrations/aws_ecs.py
@@ -71,13 +71,15 @@ from paradime.core.scripts.aws_ecs import list_ecs_task_definitions, trigger_ecs
 )
 @click.option(
     "--wait/--no-wait",
+    envvar="AWS_ECS_TRIGGER_WAIT",
     default=True,
-    help="Wait for tasks to complete before returning",
+    help="Wait for tasks to complete before returning\n\n [env: AWS_ECS_TRIGGER_WAIT]",
 )
 @click.option(
     "--timeout",
     type=int,
-    help="Maximum time to wait in minutes.",
+    envvar="AWS_ECS_TRIGGER_TIMEOUT",
+    help="Maximum time to wait in minutes.\n\n [env: AWS_ECS_TRIGGER_TIMEOUT]",
     default=1440,
 )
 @click.option("--json", "json_output", is_flag=True, help="Output results as JSON.", default=False)

--- a/paradime/cli/integrations/aws_glue.py
+++ b/paradime/cli/integrations/aws_glue.py
@@ -48,13 +48,15 @@ from paradime.core.scripts.aws_glue import (
 )
 @click.option(
     "--wait/--no-wait",
-    help="Wait for workflow runs to complete before returning",
+    envvar="AWS_GLUE_TRIGGER_WORKFLOWS_WAIT",
+    help="Wait for workflow runs to complete before returning\n\n [env: AWS_GLUE_TRIGGER_WORKFLOWS_WAIT]",
     default=True,
 )
 @click.option(
     "--timeout",
     type=int,
-    help="Maximum time to wait in minutes.",
+    envvar="AWS_GLUE_TRIGGER_WORKFLOWS_TIMEOUT",
+    help="Maximum time to wait in minutes.\n\n [env: AWS_GLUE_TRIGGER_WORKFLOWS_TIMEOUT]",
     default=1440,
 )
 @click.option("--json", "json_output", is_flag=True, help="Output results as JSON.", default=False)
@@ -210,13 +212,15 @@ def aws_glue_list_workflows(
 )
 @click.option(
     "--wait/--no-wait",
-    help="Wait for job runs to complete before returning",
+    envvar="AWS_GLUE_TRIGGER_JOBS_WAIT",
+    help="Wait for job runs to complete before returning\n\n [env: AWS_GLUE_TRIGGER_JOBS_WAIT]",
     default=True,
 )
 @click.option(
     "--timeout",
     type=int,
-    help="Maximum time to wait in minutes.",
+    envvar="AWS_GLUE_TRIGGER_JOBS_TIMEOUT",
+    help="Maximum time to wait in minutes.\n\n [env: AWS_GLUE_TRIGGER_JOBS_TIMEOUT]",
     default=1440,
 )
 @click.option("--json", "json_output", is_flag=True, help="Output results as JSON.", default=False)

--- a/paradime/cli/integrations/aws_lambda.py
+++ b/paradime/cli/integrations/aws_lambda.py
@@ -55,13 +55,15 @@ from paradime.core.scripts.aws_lambda import list_lambda_functions, trigger_lamb
 )
 @click.option(
     "--wait/--no-wait",
-    help="Wait for async invocations to complete before returning (only applies to Event invocation type)",
+    envvar="AWS_LAMBDA_TRIGGER_WAIT",
+    help="Wait for async invocations to complete before returning (only applies to Event invocation type)\n\n [env: AWS_LAMBDA_TRIGGER_WAIT]",
     default=True,
 )
 @click.option(
     "--timeout",
     type=int,
-    help="Maximum time to wait in minutes.",
+    envvar="AWS_LAMBDA_TRIGGER_TIMEOUT",
+    help="Maximum time to wait in minutes.\n\n [env: AWS_LAMBDA_TRIGGER_TIMEOUT]",
     default=15,
 )
 @click.option("--json", "json_output", is_flag=True, help="Output results as JSON.", default=False)

--- a/paradime/cli/integrations/aws_sagemaker.py
+++ b/paradime/cli/integrations/aws_sagemaker.py
@@ -46,13 +46,15 @@ from paradime.core.scripts.aws_sagemaker import (
 )
 @click.option(
     "--wait/--no-wait",
-    help="Wait for pipeline executions to complete before returning",
+    envvar="AWS_SAGEMAKER_TRIGGER_WAIT",
+    help="Wait for pipeline executions to complete before returning\n\n [env: AWS_SAGEMAKER_TRIGGER_WAIT]",
     default=True,
 )
 @click.option(
     "--timeout",
     type=int,
-    help="Maximum time to wait in minutes.",
+    envvar="AWS_SAGEMAKER_TRIGGER_TIMEOUT",
+    help="Maximum time to wait in minutes.\n\n [env: AWS_SAGEMAKER_TRIGGER_TIMEOUT]",
     default=1440,
 )
 @click.option("--json", "json_output", is_flag=True, help="Output results as JSON.", default=False)

--- a/paradime/cli/integrations/aws_stepfunctions.py
+++ b/paradime/cli/integrations/aws_stepfunctions.py
@@ -52,13 +52,15 @@ from paradime.core.scripts.aws_stepfunctions import (
 )
 @click.option(
     "--wait/--no-wait",
-    help="Wait for executions to complete before returning",
+    envvar="AWS_STEPFUNCTIONS_TRIGGER_WAIT",
+    help="Wait for executions to complete before returning\n\n [env: AWS_STEPFUNCTIONS_TRIGGER_WAIT]",
     default=True,
 )
 @click.option(
     "--timeout",
     type=int,
-    help="Maximum time to wait in minutes.",
+    envvar="AWS_STEPFUNCTIONS_TRIGGER_TIMEOUT",
+    help="Maximum time to wait in minutes.\n\n [env: AWS_STEPFUNCTIONS_TRIGGER_TIMEOUT]",
     default=1440,
 )
 @click.option("--json", "json_output", is_flag=True, help="Output results as JSON.", default=False)

--- a/paradime/cli/integrations/census.py
+++ b/paradime/cli/integrations/census.py
@@ -30,13 +30,15 @@ from paradime.core.scripts.census import list_census_syncs, trigger_census_syncs
 )
 @click.option(
     "--wait/--no-wait",
+    envvar="CENSUS_SYNC_WAIT",
     default=True,
-    help="Wait for syncs to complete before returning (default: True)",
+    help="Wait for syncs to complete before returning (default: True)\n\n [env: CENSUS_SYNC_WAIT]",
 )
 @click.option(
     "--timeout",
     type=int,
-    help="Maximum time to wait in minutes.",
+    envvar="CENSUS_SYNC_TIMEOUT",
+    help="Maximum time to wait in minutes.\n\n [env: CENSUS_SYNC_TIMEOUT]",
     default=1440,
 )
 @click.option("--json", "json_output", is_flag=True, help="Output results as JSON.", default=False)

--- a/paradime/cli/integrations/fivetran.py
+++ b/paradime/cli/integrations/fivetran.py
@@ -41,13 +41,15 @@ from paradime.core.scripts.fivetran import list_fivetran_connectors, trigger_fiv
 )
 @click.option(
     "--wait/--no-wait",
+    envvar="FIVETRAN_SYNC_WAIT",
     default=True,
-    help="Wait for syncs to complete before returning",
+    help="Wait for syncs to complete before returning\n\n [env: FIVETRAN_SYNC_WAIT]",
 )
 @click.option(
     "--timeout",
     type=int,
-    help="Maximum time to wait in minutes.",
+    envvar="FIVETRAN_SYNC_TIMEOUT",
+    help="Maximum time to wait in minutes.\n\n [env: FIVETRAN_SYNC_TIMEOUT]",
     default=1440,
 )
 @click.option("--json", "json_output", is_flag=True, help="Output results as JSON.", default=False)

--- a/paradime/cli/integrations/gcp_bigquery_transfer.py
+++ b/paradime/cli/integrations/gcp_bigquery_transfer.py
@@ -36,13 +36,15 @@ from paradime.core.scripts.gcp_bigquery_transfer import (
 )
 @click.option(
     "--wait/--no-wait",
-    help="Wait for the scheduled query run to complete before returning.",
+    envvar="GCP_BIGQUERY_TRANSFER_TRIGGER_WAIT",
+    help="Wait for the scheduled query run to complete before returning.\n\n [env: GCP_BIGQUERY_TRANSFER_TRIGGER_WAIT]",
     default=True,
 )
 @click.option(
     "--timeout-minutes",
     type=int,
-    help="Maximum time to wait for completion (in minutes). Only used with --wait.",
+    envvar="GCP_BIGQUERY_TRANSFER_TRIGGER_TIMEOUT_MINUTES",
+    help="Maximum time to wait for completion (in minutes). Only used with --wait.\n\n [env: GCP_BIGQUERY_TRANSFER_TRIGGER_TIMEOUT_MINUTES]",
     default=1440,
 )
 def gcp_bigquery_transfer_trigger(

--- a/paradime/cli/integrations/gcp_bigquery_transfer.py
+++ b/paradime/cli/integrations/gcp_bigquery_transfer.py
@@ -41,10 +41,10 @@ from paradime.core.scripts.gcp_bigquery_transfer import (
     default=True,
 )
 @click.option(
-    "--timeout-minutes",
+    "--timeout",
     type=int,
-    envvar="GCP_BIGQUERY_TRANSFER_TRIGGER_TIMEOUT_MINUTES",
-    help="Maximum time to wait for completion (in minutes). Only used with --wait.\n\n [env: GCP_BIGQUERY_TRANSFER_TRIGGER_TIMEOUT_MINUTES]",
+    envvar="GCP_BIGQUERY_TRANSFER_TRIGGER_TIMEOUT",
+    help="Maximum time to wait for completion (in minutes). Only used with --wait.\n\n [env: GCP_BIGQUERY_TRANSFER_TRIGGER_TIMEOUT]",
     default=1440,
 )
 def gcp_bigquery_transfer_trigger(
@@ -53,7 +53,7 @@ def gcp_bigquery_transfer_trigger(
     location: str,
     scheduled_query_names: List[str],
     wait: bool,
-    timeout_minutes: int,
+    timeout: int,
 ) -> None:
     """
     Trigger BigQuery scheduled queries by display name.
@@ -67,7 +67,7 @@ def gcp_bigquery_transfer_trigger(
             location=location,
             scheduled_query_names=scheduled_query_names,
             wait_for_completion=wait,
-            timeout_minutes=timeout_minutes,
+            timeout_minutes=timeout,
         )
 
         failed = [r for r in results if "FAILED" in r or "CANCELLED" in r]

--- a/paradime/cli/integrations/gcp_cloud_function.py
+++ b/paradime/cli/integrations/gcp_cloud_function.py
@@ -41,10 +41,10 @@ from paradime.core.scripts.gcp_cloud_function import list_cloud_functions, trigg
     default=True,
 )
 @click.option(
-    "--timeout-minutes",
+    "--timeout",
     type=int,
-    envvar="GCP_CLOUD_FUNCTION_TRIGGER_TIMEOUT_MINUTES",
-    help="Maximum time to wait for completion (in minutes). Only used with --wait.\n\n [env: GCP_CLOUD_FUNCTION_TRIGGER_TIMEOUT_MINUTES]",
+    envvar="GCP_CLOUD_FUNCTION_TRIGGER_TIMEOUT",
+    help="Maximum time to wait for completion (in minutes). Only used with --wait.\n\n [env: GCP_CLOUD_FUNCTION_TRIGGER_TIMEOUT]",
     default=30,
 )
 def gcp_cloud_function_trigger(
@@ -54,7 +54,7 @@ def gcp_cloud_function_trigger(
     function_names: List[str],
     payload: Optional[str],
     wait: bool,
-    timeout_minutes: int,
+    timeout: int,
 ) -> None:
     """
     Invoke Google Cloud Functions by name.
@@ -69,7 +69,7 @@ def gcp_cloud_function_trigger(
             function_names=function_names,
             payload=payload,
             wait_for_completion=wait,
-            timeout_minutes=timeout_minutes,
+            timeout_minutes=timeout,
         )
 
         failed = [r for r in results if "FAILED" in r]

--- a/paradime/cli/integrations/gcp_cloud_function.py
+++ b/paradime/cli/integrations/gcp_cloud_function.py
@@ -36,13 +36,15 @@ from paradime.core.scripts.gcp_cloud_function import list_cloud_functions, trigg
 )
 @click.option(
     "--wait/--no-wait",
-    help="Wait for the function invocation to complete before returning.",
+    envvar="GCP_CLOUD_FUNCTION_TRIGGER_WAIT",
+    help="Wait for the function invocation to complete before returning.\n\n [env: GCP_CLOUD_FUNCTION_TRIGGER_WAIT]",
     default=True,
 )
 @click.option(
     "--timeout-minutes",
     type=int,
-    help="Maximum time to wait for completion (in minutes). Only used with --wait.",
+    envvar="GCP_CLOUD_FUNCTION_TRIGGER_TIMEOUT_MINUTES",
+    help="Maximum time to wait for completion (in minutes). Only used with --wait.\n\n [env: GCP_CLOUD_FUNCTION_TRIGGER_TIMEOUT_MINUTES]",
     default=30,
 )
 def gcp_cloud_function_trigger(

--- a/paradime/cli/integrations/gcp_cloud_run.py
+++ b/paradime/cli/integrations/gcp_cloud_run.py
@@ -31,13 +31,15 @@ from paradime.core.scripts.gcp_cloud_run import list_cloud_run_jobs, trigger_clo
 )
 @click.option(
     "--wait/--no-wait",
-    help="Wait for the job execution to complete before returning.",
+    envvar="GCP_CLOUD_RUN_TRIGGER_WAIT",
+    help="Wait for the job execution to complete before returning.\n\n [env: GCP_CLOUD_RUN_TRIGGER_WAIT]",
     default=True,
 )
 @click.option(
     "--timeout-minutes",
     type=int,
-    help="Maximum time to wait for completion (in minutes). Only used with --wait.",
+    envvar="GCP_CLOUD_RUN_TRIGGER_TIMEOUT_MINUTES",
+    help="Maximum time to wait for completion (in minutes). Only used with --wait.\n\n [env: GCP_CLOUD_RUN_TRIGGER_TIMEOUT_MINUTES]",
     default=1440,
 )
 def gcp_cloud_run_trigger(

--- a/paradime/cli/integrations/gcp_cloud_run.py
+++ b/paradime/cli/integrations/gcp_cloud_run.py
@@ -36,10 +36,10 @@ from paradime.core.scripts.gcp_cloud_run import list_cloud_run_jobs, trigger_clo
     default=True,
 )
 @click.option(
-    "--timeout-minutes",
+    "--timeout",
     type=int,
-    envvar="GCP_CLOUD_RUN_TRIGGER_TIMEOUT_MINUTES",
-    help="Maximum time to wait for completion (in minutes). Only used with --wait.\n\n [env: GCP_CLOUD_RUN_TRIGGER_TIMEOUT_MINUTES]",
+    envvar="GCP_CLOUD_RUN_TRIGGER_TIMEOUT",
+    help="Maximum time to wait for completion (in minutes). Only used with --wait.\n\n [env: GCP_CLOUD_RUN_TRIGGER_TIMEOUT]",
     default=1440,
 )
 def gcp_cloud_run_trigger(
@@ -48,7 +48,7 @@ def gcp_cloud_run_trigger(
     location: str,
     job_names: List[str],
     wait: bool,
-    timeout_minutes: int,
+    timeout: int,
 ) -> None:
     """
     Trigger Cloud Run Jobs by name.
@@ -62,7 +62,7 @@ def gcp_cloud_run_trigger(
             location=location,
             job_names=job_names,
             wait_for_completion=wait,
-            timeout_minutes=timeout_minutes,
+            timeout_minutes=timeout,
         )
 
         failed = [r for r in results if "FAILED" in r]

--- a/paradime/cli/integrations/gcp_dataflow.py
+++ b/paradime/cli/integrations/gcp_dataflow.py
@@ -46,13 +46,15 @@ from paradime.core.scripts.gcp_dataflow import trigger_dataflow_job
 )
 @click.option(
     "--wait/--no-wait",
-    help="Wait for the Dataflow job to complete before returning.",
+    envvar="GCP_DATAFLOW_TRIGGER_WAIT",
+    help="Wait for the Dataflow job to complete before returning.\n\n [env: GCP_DATAFLOW_TRIGGER_WAIT]",
     default=True,
 )
 @click.option(
     "--timeout-minutes",
     type=int,
-    help="Maximum time to wait for completion (in minutes). Only used with --wait.",
+    envvar="GCP_DATAFLOW_TRIGGER_TIMEOUT_MINUTES",
+    help="Maximum time to wait for completion (in minutes). Only used with --wait.\n\n [env: GCP_DATAFLOW_TRIGGER_TIMEOUT_MINUTES]",
     default=1440,
 )
 def gcp_dataflow_trigger(

--- a/paradime/cli/integrations/gcp_dataflow.py
+++ b/paradime/cli/integrations/gcp_dataflow.py
@@ -51,10 +51,10 @@ from paradime.core.scripts.gcp_dataflow import trigger_dataflow_job
     default=True,
 )
 @click.option(
-    "--timeout-minutes",
+    "--timeout",
     type=int,
-    envvar="GCP_DATAFLOW_TRIGGER_TIMEOUT_MINUTES",
-    help="Maximum time to wait for completion (in minutes). Only used with --wait.\n\n [env: GCP_DATAFLOW_TRIGGER_TIMEOUT_MINUTES]",
+    envvar="GCP_DATAFLOW_TRIGGER_TIMEOUT",
+    help="Maximum time to wait for completion (in minutes). Only used with --wait.\n\n [env: GCP_DATAFLOW_TRIGGER_TIMEOUT]",
     default=1440,
 )
 def gcp_dataflow_trigger(
@@ -66,7 +66,7 @@ def gcp_dataflow_trigger(
     template_type: str,
     parameters: Optional[str],
     wait: bool,
-    timeout_minutes: int,
+    timeout: int,
 ) -> None:
     """
     Launch a Dataflow job from a template (classic or flex).
@@ -83,7 +83,7 @@ def gcp_dataflow_trigger(
             template_type=template_type,
             parameters=parameters,
             wait_for_completion=wait,
-            timeout_minutes=timeout_minutes,
+            timeout_minutes=timeout,
         )
 
         failed = [r for r in results if "FAILED" in r]

--- a/paradime/cli/integrations/gcp_dataproc.py
+++ b/paradime/cli/integrations/gcp_dataproc.py
@@ -57,13 +57,15 @@ from paradime.core.scripts.gcp_dataproc import list_dataproc_clusters, trigger_d
 )
 @click.option(
     "--wait/--no-wait",
-    help="Wait for the Dataproc job to complete before returning.",
+    envvar="GCP_DATAPROC_TRIGGER_WAIT",
+    help="Wait for the Dataproc job to complete before returning.\n\n [env: GCP_DATAPROC_TRIGGER_WAIT]",
     default=True,
 )
 @click.option(
     "--timeout-minutes",
     type=int,
-    help="Maximum time to wait for completion (in minutes). Only used with --wait.",
+    envvar="GCP_DATAPROC_TRIGGER_TIMEOUT_MINUTES",
+    help="Maximum time to wait for completion (in minutes). Only used with --wait.\n\n [env: GCP_DATAPROC_TRIGGER_TIMEOUT_MINUTES]",
     default=1440,
 )
 def gcp_dataproc_trigger(

--- a/paradime/cli/integrations/gcp_dataproc.py
+++ b/paradime/cli/integrations/gcp_dataproc.py
@@ -62,10 +62,10 @@ from paradime.core.scripts.gcp_dataproc import list_dataproc_clusters, trigger_d
     default=True,
 )
 @click.option(
-    "--timeout-minutes",
+    "--timeout",
     type=int,
-    envvar="GCP_DATAPROC_TRIGGER_TIMEOUT_MINUTES",
-    help="Maximum time to wait for completion (in minutes). Only used with --wait.\n\n [env: GCP_DATAPROC_TRIGGER_TIMEOUT_MINUTES]",
+    envvar="GCP_DATAPROC_TRIGGER_TIMEOUT",
+    help="Maximum time to wait for completion (in minutes). Only used with --wait.\n\n [env: GCP_DATAPROC_TRIGGER_TIMEOUT]",
     default=1440,
 )
 def gcp_dataproc_trigger(
@@ -79,7 +79,7 @@ def gcp_dataproc_trigger(
     args: List[str],
     job_file: Optional[str],
     wait: bool,
-    timeout_minutes: int,
+    timeout: int,
 ) -> None:
     """
     Submit a job to a Dataproc cluster.
@@ -98,7 +98,7 @@ def gcp_dataproc_trigger(
             args=list(args) if args else None,
             job_file=job_file,
             wait_for_completion=wait,
-            timeout_minutes=timeout_minutes,
+            timeout_minutes=timeout,
         )
 
         failed = [r for r in results if "FAILED" in r or "ERROR" in r]

--- a/paradime/cli/integrations/gcp_datastream.py
+++ b/paradime/cli/integrations/gcp_datastream.py
@@ -37,13 +37,15 @@ from paradime.core.scripts.gcp_datastream import list_datastream_streams, trigge
 )
 @click.option(
     "--wait/--no-wait",
-    help="Wait for the state change to complete before returning.",
+    envvar="GCP_DATASTREAM_TRIGGER_WAIT",
+    help="Wait for the state change to complete before returning.\n\n [env: GCP_DATASTREAM_TRIGGER_WAIT]",
     default=True,
 )
 @click.option(
     "--timeout-minutes",
     type=int,
-    help="Maximum time to wait for completion (in minutes). Only used with --wait.",
+    envvar="GCP_DATASTREAM_TRIGGER_TIMEOUT_MINUTES",
+    help="Maximum time to wait for completion (in minutes). Only used with --wait.\n\n [env: GCP_DATASTREAM_TRIGGER_TIMEOUT_MINUTES]",
     default=60,
 )
 def gcp_datastream_trigger(

--- a/paradime/cli/integrations/gcp_datastream.py
+++ b/paradime/cli/integrations/gcp_datastream.py
@@ -42,10 +42,10 @@ from paradime.core.scripts.gcp_datastream import list_datastream_streams, trigge
     default=True,
 )
 @click.option(
-    "--timeout-minutes",
+    "--timeout",
     type=int,
-    envvar="GCP_DATASTREAM_TRIGGER_TIMEOUT_MINUTES",
-    help="Maximum time to wait for completion (in minutes). Only used with --wait.\n\n [env: GCP_DATASTREAM_TRIGGER_TIMEOUT_MINUTES]",
+    envvar="GCP_DATASTREAM_TRIGGER_TIMEOUT",
+    help="Maximum time to wait for completion (in minutes). Only used with --wait.\n\n [env: GCP_DATASTREAM_TRIGGER_TIMEOUT]",
     default=60,
 )
 def gcp_datastream_trigger(
@@ -55,7 +55,7 @@ def gcp_datastream_trigger(
     stream_names: List[str],
     action: str,
     wait: bool,
-    timeout_minutes: int,
+    timeout: int,
 ) -> None:
     """
     Start, pause, or resume Datastream streams by display name.
@@ -70,7 +70,7 @@ def gcp_datastream_trigger(
             stream_names=stream_names,
             action=action,
             wait_for_completion=wait,
-            timeout_minutes=timeout_minutes,
+            timeout_minutes=timeout,
         )
 
         failed = [r for r in results if "FAILED" in r]

--- a/paradime/cli/integrations/github_actions.py
+++ b/paradime/cli/integrations/github_actions.py
@@ -40,13 +40,15 @@ from paradime.core.scripts.github_actions import list_github_workflows, trigger_
 )
 @click.option(
     "--wait/--no-wait",
+    envvar="GITHUB_ACTIONS_TRIGGER_WAIT",
     default=True,
-    help="Wait for workflow runs to complete before returning.",
+    help="Wait for workflow runs to complete before returning.\n\n [env: GITHUB_ACTIONS_TRIGGER_WAIT]",
 )
 @click.option(
     "--timeout",
     type=int,
-    help="Maximum time to wait in minutes.",
+    envvar="GITHUB_ACTIONS_TRIGGER_TIMEOUT",
+    help="Maximum time to wait in minutes.\n\n [env: GITHUB_ACTIONS_TRIGGER_TIMEOUT]",
     default=1440,
 )
 @click.option("--json", "json_output", is_flag=True, help="Output results as JSON.", default=False)

--- a/paradime/cli/integrations/hex.py
+++ b/paradime/cli/integrations/hex.py
@@ -40,13 +40,15 @@ from paradime.core.scripts.hex import list_hex_projects, trigger_hex_runs
 )
 @click.option(
     "--wait/--no-wait",
+    envvar="HEX_TRIGGER_WAIT",
     default=True,
-    help="Wait for runs to complete before returning (default: True)",
+    help="Wait for runs to complete before returning (default: True)\n\n [env: HEX_TRIGGER_WAIT]",
 )
 @click.option(
     "--timeout",
     type=int,
-    help="Maximum time to wait in minutes.",
+    envvar="HEX_TRIGGER_TIMEOUT",
+    help="Maximum time to wait in minutes.\n\n [env: HEX_TRIGGER_TIMEOUT]",
     default=1440,
 )
 @click.option("--json", "json_output", is_flag=True, help="Output results as JSON.", default=False)

--- a/paradime/cli/integrations/hightouch.py
+++ b/paradime/cli/integrations/hightouch.py
@@ -35,13 +35,15 @@ from paradime.core.scripts.hightouch import (
 )
 @click.option(
     "--wait/--no-wait",
+    envvar="HIGHTOUCH_SYNC_WAIT",
     default=True,
-    help="Wait for syncs to complete before returning (default: True)",
+    help="Wait for syncs to complete before returning (default: True)\n\n [env: HIGHTOUCH_SYNC_WAIT]",
 )
 @click.option(
     "--timeout",
     type=int,
-    help="Maximum time to wait in minutes.",
+    envvar="HIGHTOUCH_SYNC_TIMEOUT",
+    help="Maximum time to wait in minutes.\n\n [env: HIGHTOUCH_SYNC_TIMEOUT]",
     default=1440,
 )
 @click.option("--json", "json_output", is_flag=True, help="Output results as JSON.", default=False)
@@ -115,13 +117,15 @@ def hightouch_sync(
 )
 @click.option(
     "--wait/--no-wait",
+    envvar="HIGHTOUCH_SYNC_SEQUENCE_WAIT",
     default=True,
-    help="Wait for sync sequences to complete before returning (default: True)",
+    help="Wait for sync sequences to complete before returning (default: True)\n\n [env: HIGHTOUCH_SYNC_SEQUENCE_WAIT]",
 )
 @click.option(
     "--timeout",
     type=int,
-    help="Maximum time to wait in minutes.",
+    envvar="HIGHTOUCH_SYNC_SEQUENCE_TIMEOUT",
+    help="Maximum time to wait in minutes.\n\n [env: HIGHTOUCH_SYNC_SEQUENCE_TIMEOUT]",
     default=1440,
 )
 @click.option("--json", "json_output", is_flag=True, help="Output results as JSON.", default=False)

--- a/paradime/cli/integrations/matillion.py
+++ b/paradime/cli/integrations/matillion.py
@@ -48,13 +48,15 @@ from paradime.core.scripts.matillion import (
 )
 @click.option(
     "--wait/--no-wait",
-    help="Wait for pipeline executions to complete before returning",
+    envvar="MATILLION_PIPELINE_WAIT",
+    help="Wait for pipeline executions to complete before returning\n\n [env: MATILLION_PIPELINE_WAIT]",
     default=True,
 )
 @click.option(
     "--timeout",
     type=int,
-    help="Maximum time to wait in minutes.",
+    envvar="MATILLION_PIPELINE_TIMEOUT",
+    help="Maximum time to wait in minutes.\n\n [env: MATILLION_PIPELINE_TIMEOUT]",
     default=1440,
 )
 @click.option("--json", "json_output", is_flag=True, help="Output results as JSON.", default=False)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "paradime-io"
-version = "5.11.0"
+version = "5.12.0"
 description = "Paradime - Python SDK"
 authors = [
     { name = "Bhuvan Singla", email = "bhuvan@paradime.io" },

--- a/uv.lock
+++ b/uv.lock
@@ -916,7 +916,7 @@ wheels = [
 
 [[package]]
 name = "paradime-io"
-version = "5.10.0"
+version = "5.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## Summary
- Env-backs `--wait/--no-wait` and `--timeout` flags across 22 trigger/sync commands using a uniform `<COMMAND>_<FLAG>` pattern that matches the existing Tableau (`TABLEAU_REFRESH_WAIT`) and Power BI (`POWER_BI_REFRESH_WAIT`) convention.
- Renames the GCP `--timeout-minutes` flag to `--timeout` so every integration's flag name is identical (pre-release rename — no shipped consumers per discussion).
- Help text now shows `[env: <VAR>]` inline for every newly-backed option. Defaults unchanged; CLI flags still override env vars.

## Examples
| Command | New env vars |
|---|---|
| `airflow-trigger` | `AIRFLOW_TRIGGER_WAIT`, `AIRFLOW_TRIGGER_TIMEOUT` |
| `census-sync` | `CENSUS_SYNC_WAIT`, `CENSUS_SYNC_TIMEOUT` |
| `aws-glue-trigger-workflows` | `AWS_GLUE_TRIGGER_WORKFLOWS_WAIT`, `AWS_GLUE_TRIGGER_WORKFLOWS_TIMEOUT` |
| `gcp-dataflow-trigger` | `GCP_DATAFLOW_TRIGGER_WAIT`, `GCP_DATAFLOW_TRIGGER_TIMEOUT` |

## What this does NOT touch
- Tableau (`TABLEAU_REFRESH_WAIT`/`_TIMEOUT_MINUTES`) — released, kept as-is
- Power BI (`POWER_BI_REFRESH_WAIT`/`_TIMEOUT_MINUTES`) — handled on its own branch
- Airflow `--poll-interval` / `AIRFLOW_POLL_INTERVAL` — already env-backed in PR #110
- Zapier / Datahub / Montecarlo — no async, no flags to back
- Core script function signatures still take `timeout_minutes` (descriptive internal API)

## Breaking change to flag for review
GCP CLI `--timeout-minutes` → `--timeout`. Anyone invoking `paradime run gcp-*-trigger --timeout-minutes N` will see "no such option" after this lands. Confirmed with @fabio that this is acceptable pre-release. Easy mitigation if needed: add `@deprecated_alias_option("timeout-minutes", "timeout", type=int)` per file.

## Test plan
- [ ] `paradime run airflow-trigger --help` — verify `[env: AIRFLOW_TRIGGER_WAIT]` and `[env: AIRFLOW_TRIGGER_TIMEOUT]` appear
- [ ] `paradime run gcp-cloud-run-trigger --help` — verify `--timeout` (not `--timeout-minutes`) and `[env: GCP_CLOUD_RUN_TRIGGER_TIMEOUT]`
- [ ] `AIRBYTE_SYNC_WAIT=false paradime run airbyte-sync --connection-ids X --job-type sync` — verify env var picked up (fire-and-forget, no waiting)
- [ ] `CENSUS_SYNC_TIMEOUT=30 paradime run census-sync --sync-ids X` — verify env-set timeout used
- [ ] CLI flag still overrides env: `AIRBYTE_SYNC_WAIT=false paradime run airbyte-sync --wait …` waits

🤖 Generated with [Claude Code](https://claude.com/claude-code)