### PR TITLE
feat(bolt): add reason parameter to trigger_run

### DIFF
--- a/examples/bolt/trigger_run.py
+++ b/examples/bolt/trigger_run.py
@@ -17,5 +17,11 @@ run_id_with_pr = paradime.bolt.trigger_run(
     pr_number=123,
 )
 
+# Trigger a run with a reason describing why/from where it was triggered
+run_id_with_reason = paradime.bolt.trigger_run(
+    BOLT_SCHEDULE_NAME,
+    reason="triggered by data-quality-bot",
+)
+
 # Get the run status
 run_status = paradime.bolt.get_run_status(run_id)

--- a/paradime/apis/bolt/client.py
+++ b/paradime/apis/bolt/client.py
@@ -129,6 +129,7 @@ class BoltClient:
         pr_number: Optional[int] = None,
         *,
         slug: Optional[str] = None,
+        reason: Optional[str] = None,
     ) -> int:
         """
         Triggers a run for a given schedule.
@@ -139,6 +140,7 @@ class BoltClient:
             branch (Optional[str], optional): The branch or commit hash to run the commands on. Defaults to None.
             pr_number (Optional[int], optional): The pull request number to associate with the run. Defaults to None.
             slug (Optional[str]): The schedule slug returned by ``createBoltSchedule``. Preferred over ``schedule_name``.
+            reason (Optional[str], optional): A freeform reason/label describing why or from where the run was triggered (e.g. the application that made the call). Defaults to None.
 
         Returns:
             int: The ID of the triggered run.
@@ -149,8 +151,8 @@ class BoltClient:
         )
 
         query = """
-            mutation triggerBoltRun($slug: String, $commands: [String!], $branch: String, $prNumber: Int) {
-                triggerBoltRun(slug: $slug, commands: $commands, branch: $branch, prNumber: $prNumber){
+            mutation triggerBoltRun($slug: String, $commands: [String!], $branch: String, $prNumber: Int, $reason: String) {
+                triggerBoltRun(slug: $slug, commands: $commands, branch: $branch, prNumber: $prNumber, reason: $reason){
                     runId
                 }
             }
@@ -163,6 +165,7 @@ class BoltClient:
                 "commands": commands,
                 "branch": branch,
                 "prNumber": pr_number,
+                "reason": reason,
             },
         )["triggerBoltRun"]
 

--- a/paradime/cli/bolt.py
+++ b/paradime/cli/bolt.py
@@ -175,6 +175,11 @@ schedule.add_command(schedule_retry)
 @click.option(
     "--pr-number", default=None, type=int, help="Pull request number to associate with the run."
 )
+@click.option(
+    "--reason",
+    default=None,
+    help="Freeform reason/label describing why or from where the run was triggered.",
+)
 @click.option("--wait", help="Wait for the run to finish", is_flag=True)
 @click.option("--json", help="JSON formatted response", is_flag=True)
 @click.argument("slug")
@@ -182,6 +187,7 @@ def run(
     branch: str,
     command: List[str],
     pr_number: Optional[int],
+    reason: Optional[str],
     wait: bool,
     json: bool,
     slug: str,
@@ -202,6 +208,7 @@ def run(
             branch=branch,
             commands=list(command) if command else None,
             pr_number=pr_number,
+            reason=reason,
         )
     except ParadimeAPIException as e:
         print_error_table(f"Failed to trigger run: {e}", is_json=json)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "paradime-io"
-version = "5.12.0"
+version = "5.13.0"
 description = "Paradime - Python SDK"
 authors = [
     { name = "Bhuvan Singla", email = "bhuvan@paradime.io" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "paradime-io"
-version = "6.0.0"
+version = "6.1.0"
 description = "Paradime - Python SDK"
 authors = [
     { name = "Bhuvan Singla", email = "bhuvan@paradime.io" },

--- a/uv.lock
+++ b/uv.lock
@@ -916,7 +916,7 @@ wheels = [
 
 [[package]]
 name = "paradime-io"
-version = "5.11.0"
+version = "6.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## Summary

Adds a new optional `reason` field to Bolt's `trigger_run` so callers can record **why** or **from where** a run was triggered (e.g. the application or bot that made the call). The value flows through the SDK client, the GraphQL mutation, and the CLI.

## Changes

- **`paradime/apis/bolt/client.py`** — `trigger_run` gains an optional `reason` keyword argument, wired into the `triggerBoltRun` GraphQL mutation as a new `$reason: String` variable.
- **`paradime/cli/bolt.py`** — adds a `--reason` option to the `bolt schedule run` command, forwarded to `trigger_run`.
- **`examples/bolt/trigger_run.py`** — example showing how to pass a `reason`.
- **`pyproject.toml`** — version bump `5.12.0` → `5.13.0`.

## Usage

```python
run_id = paradime.bolt.trigger_run(
    BOLT_SCHEDULE_NAME,
    reason="triggered by data-quality-bot",
)
```

```bash
paradime bolt schedule run <slug> --reason "triggered by data-quality-bot"
```

The field is fully optional and backward compatible — existing callers are unaffected.
