### PR TITLE
Support company-level and workspace bearer-token authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,26 @@ pip install paradime-io
 
 ## SDK Usage
 
-Generate your API key, secret and endpoint from Paradime workspace settings.
+Generate your API credentials from Paradime workspace settings.
+
+You can authenticate with a bearer token (recommended) — either a workspace-level token
+(`prdm_wsp_...`) or a company-level token (`prdm_cmp_...`, requires `workspace_uid` to
+select which workspace requests target). Pass it as `api_secret`; the SDK detects the
+token type automatically from its prefix and `api_key` is not needed:
+
+```python
+from paradime import Paradime
+
+paradime = Paradime(
+    api_endpoint="API_ENDPOINT",
+    api_secret="API_TOKEN",  # e.g. prdm_wsp_... or prdm_cmp_...
+    # workspace_uid="WORKSPACE_UID",  # required when using a company-level (prdm_cmp_) token
+)
+
+# Use the paradime client to interact with the API
+```
+
+Or with the legacy API key + secret pair:
 
 ```python
 from paradime import Paradime
@@ -37,13 +56,25 @@ For the full specification of the CLI, run:
 paradime --help
 ```
 
-Generate your API key, secret and endpoint from Paradime workspace settings. Then set the environment variables:
+Generate your API credentials from Paradime workspace settings. Then set the environment variables.
+
+Using a bearer token (recommended):
+
+```bash
+export PARADIME_API_ENDPOINT="YOUR_API_ENDPOINT"
+export PARADIME_API_SECRET="YOUR_API_TOKEN" # e.g. prdm_wsp_... or prdm_cmp_...
+export PARADIME_WORKSPACE_UID="YOUR_WORKSPACE_UID" # required when using a company-level (prdm_cmp_) token
+```
+
+Or using the legacy API key + secret pair:
 
 ```bash
 export PARADIME_API_ENDPOINT="YOUR_API_ENDPOINT"
 export PARADIME_API_KEY="YOUR_API_KEY"
 export PARADIME_API_SECRET="YOUR_API_SECRET
 ```
+
+Alternatively, run `paradime login` to be prompted for either set of credentials, which will be stored locally.
 
 ## Examples
 

--- a/paradime/cli/login.py
+++ b/paradime/cli/login.py
@@ -23,13 +23,35 @@ def login() -> None:
         "https://app.paradime.io/settings/current-workspace",
     )
 
-    api_key = click.prompt("Enter API Key")
-    api_secret = click.prompt("Enter API Secret", hide_input=True)
+    api_secret = click.prompt(
+        "Enter API Secret (or API Token, e.g. one starting with 'prdm_wsp_' or 'prdm_cmp_')",
+        hide_input=True,
+    )
+
+    credentials_lines = []
+
+    if api_secret.startswith("prdm_wsp_") or api_secret.startswith("prdm_cmp_"):
+        workspace_uid = ""
+        if api_secret.startswith("prdm_cmp_"):
+            workspace_uid = click.prompt("Enter Workspace UID")
+            while not workspace_uid:
+                console.error(
+                    "Workspace UID is required when using a company-level ('prdm_cmp_') API token."
+                )
+                workspace_uid = click.prompt("Enter Workspace UID")
+
+        credentials_lines.append(f"API_SECRET={api_secret}")
+        if workspace_uid:
+            credentials_lines.append(f"WORKSPACE_UID={workspace_uid}")
+    else:
+        api_key = click.prompt("Enter API Key")
+        credentials_lines.append(f"API_KEY={api_key}")
+        credentials_lines.append(f"API_SECRET={api_secret}")
+
     api_endpoint = click.prompt("Enter API Endpoint")
+    credentials_lines.insert(0, f"API_ENDPOINT={api_endpoint}")
 
     # write to env file
     credentials_path.parent.mkdir(parents=True, exist_ok=True)
-    credentials_path.write_text(
-        f"API_ENDPOINT={api_endpoint}\nAPI_KEY={api_key}\nAPI_SECRET={api_secret}\n"
-    )
+    credentials_path.write_text("\n".join(credentials_lines) + "\n")
     console.success(f"Credentials written to '{credentials_path}'.")

--- a/paradime/client/api_client.py
+++ b/paradime/client/api_client.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import requests
 
@@ -6,14 +6,44 @@ from paradime.client.api_exception import ParadimeAPIException
 from paradime.client.runtime import detect_runtime, get_python_version, is_telemetry_enabled
 from paradime.version import get_sdk_version
 
+# Prefixes used by the bearer-token style API secrets. A company token is valid across a
+# set of workspaces, so every request must select its target workspace via the
+# X-Paradime-Workspace header. A workspace token is scoped to a single workspace already,
+# same as a legacy key/secret pair.
+COMPANY_API_TOKEN_PREFIX = "prdm_cmp_"
+WORKSPACE_API_TOKEN_PREFIX = "prdm_wsp_"
+
+WORKSPACE_SELECTION_HEADER = "X-Paradime-Workspace"
+
+
+def _is_bearer_token(api_secret: str) -> bool:
+    """Return True if `api_secret` is actually a bearer token rather than a legacy secret."""
+
+    return api_secret.startswith(COMPANY_API_TOKEN_PREFIX) or api_secret.startswith(
+        WORKSPACE_API_TOKEN_PREFIX
+    )
+
 
 class APIClient:
     """
     A client for making API requests to the Paradime API.
 
+    `api_secret` accepts either a legacy API secret (used together with `api_key`), or a
+    bearer token generated from Paradime account settings: a workspace-level token
+    (`prdm_wsp_...`) or a company-level token (`prdm_cmp_...`). The right auth mechanism is
+    detected automatically from the `api_secret` prefix.
+
+    - Legacy secret: `api_key` must also be provided.
+    - Workspace token (`prdm_wsp_...`): `api_key` is not needed.
+    - Company token (`prdm_cmp_...`): `api_key` is not needed, but `workspace_uid` must be
+      provided to select which workspace the requests should target.
+
     Args:
-        api_key (str): The API key for authentication.
-        api_secret (str): The API secret for authentication.
+        api_key (str, optional): The API key for authentication. Required when `api_secret`
+            is a legacy secret; not needed when `api_secret` is a bearer token.
+        api_secret (str): The API secret or bearer token for authentication.
+        workspace_uid (str, optional): The workspace uid to target. Required when
+            `api_secret` is a company-level (`prdm_cmp_`) token; not used otherwise.
         api_endpoint (str): The endpoint URL for the API.
         timeout (int, optional): The timeout for API requests in seconds. Defaults to 60 seconds.
     """
@@ -21,13 +51,27 @@ class APIClient:
     def __init__(
         self,
         *,
-        api_key: str,
+        api_key: Optional[str] = None,
         api_secret: str,
+        workspace_uid: Optional[str] = None,
         api_endpoint: str,
         timeout: int = 60,
     ):
+        if _is_bearer_token(api_secret):
+            if api_secret.startswith(COMPANY_API_TOKEN_PREFIX) and not workspace_uid:
+                raise ValueError(
+                    "workspace_uid is required when authenticating with a company-level "
+                    f"API token (one that starts with {COMPANY_API_TOKEN_PREFIX!r})."
+                )
+        elif not api_key:
+            raise ValueError(
+                "api_key is required when api_secret is a legacy API secret (i.e. does not "
+                f"start with {WORKSPACE_API_TOKEN_PREFIX!r} or {COMPANY_API_TOKEN_PREFIX!r})."
+            )
+
         self.api_key = api_key
         self.api_secret = api_secret
+        self.workspace_uid = workspace_uid
         self.api_endpoint = api_endpoint
         self.timeout = timeout
 
@@ -41,10 +85,21 @@ class APIClient:
 
         headers: Dict[str, str] = {
             "Content-Type": "application/json",
-            "X-API-KEY": self.api_key,
-            "X-API-SECRET": self.api_secret,
             "X-PYTHON-SDK-VERSION": get_sdk_version(),
         }
+
+        if _is_bearer_token(self.api_secret):
+            auth_scheme = "Bearer"
+            headers["Authorization"] = auth_scheme + " " + self.api_secret
+        else:
+            # Legacy workspace-level key/secret auth. api_key is guaranteed to be set here
+            # (validated in __init__ when api_secret is not a bearer token).
+            assert self.api_key
+            headers["X-API-KEY"] = self.api_key
+            headers["X-API-SECRET"] = self.api_secret
+
+        if self.workspace_uid:
+            headers[WORKSPACE_SELECTION_HEADER] = self.workspace_uid
 
         if is_telemetry_enabled():
             headers["X-PYTHON-VERSION"] = get_python_version()

--- a/paradime/client/paradime_cli_client.py
+++ b/paradime/client/paradime_cli_client.py
@@ -2,7 +2,7 @@ import logging
 import os
 import sys
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 
 from paradime.client.paradime_client import Paradime
 
@@ -25,12 +25,19 @@ def get_cli_client() -> Paradime:
     """
     It is recommended to use `PARADIME_` prefixed environment variables to set the API credentials.
     The ones without the prefix are deprecated and present for backward compatibility only.
+
+    `PARADIME_API_SECRET` may be a legacy API secret (used together with `PARADIME_API_KEY`)
+    or a bearer token (workspace-level `prdm_wsp_...` or company-level `prdm_cmp_...`) — the
+    right auth mechanism is detected automatically.
     """
 
     return Paradime(
         api_endpoint=get_env_var_from_aliases(["PARADIME_API_ENDPOINT", "API_ENDPOINT"]),
-        api_key=get_env_var_from_aliases(["PARADIME_API_KEY", "API_KEY"]),
+        api_key=get_optional_env_var_from_aliases(["PARADIME_API_KEY", "API_KEY"]),
         api_secret=get_env_var_from_aliases(["PARADIME_API_SECRET", "API_SECRET"]),
+        workspace_uid=get_optional_env_var_from_aliases(
+            ["PARADIME_WORKSPACE_UID", "WORKSPACE_UID"]
+        ),
     )
 
 
@@ -42,13 +49,28 @@ def get_env_var_from_aliases(
     If none are set, raise an error.
     """
 
-    for env_var in env_var_aliases:
-        value = os.getenv(env_var)
-        if value:
-            return value
+    value = get_optional_env_var_from_aliases(env_var_aliases)
+    if value:
+        return value
 
     raise ValueError(
         f"{env_var_aliases[0]} environment variable is not set! To fix this either: \n"
         f" 1. Export the environment variable (export {env_var_aliases[0]}=...) or, \n"
         f" 2. Use the `paradime login` command to set the API credentials locally."
     )
+
+
+def get_optional_env_var_from_aliases(
+    env_var_aliases: List[str],
+) -> Optional[str]:
+    """
+    Go through the list of environment variable aliases and return the first one that is set.
+    If none are set, return None.
+    """
+
+    for env_var in env_var_aliases:
+        value = os.getenv(env_var)
+        if value:
+            return value
+
+    return None

--- a/paradime/client/paradime_client.py
+++ b/paradime/client/paradime_client.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from paradime.apis.audit_log.client import AuditLogClient
 from paradime.apis.bolt.client import BoltClient
 from paradime.apis.catalog.client import CatalogClient
@@ -27,8 +29,14 @@ class Paradime(APIClient):
         workspaces (WorkspacesClient): The workspaces API client.
 
     Args:
-        api_key (str): The API key for authentication. Generate this from Paradime account settings.
-        api_secret (str): The API secret for authentication. Generate this from Paradime account settings.
+        api_key (str, optional): The API key for authentication. Required when `api_secret`
+            is a legacy secret; not needed when `api_secret` is a bearer token. Generate this
+            from Paradime account settings.
+        api_secret (str): The API secret, or a workspace-level (`prdm_wsp_`) or company-level
+            (`prdm_cmp_`) bearer token, for authentication. Generate this from Paradime
+            account settings.
+        workspace_uid (str, optional): The workspace uid to target. Required when
+            `api_secret` is a company-level (`prdm_cmp_`) token; not used otherwise.
         api_endpoint (str): The API endpoint URL. Generate this from Paradime account settings.
     """
 
@@ -42,8 +50,20 @@ class Paradime(APIClient):
     users: UsersClient
     workspaces: WorkspacesClient
 
-    def __init__(self, *, api_key: str, api_secret: str, api_endpoint: str):
-        super().__init__(api_key=api_key, api_secret=api_secret, api_endpoint=api_endpoint)
+    def __init__(
+        self,
+        *,
+        api_key: Optional[str] = None,
+        api_secret: str,
+        workspace_uid: Optional[str] = None,
+        api_endpoint: str,
+    ):
+        super().__init__(
+            api_key=api_key,
+            api_secret=api_secret,
+            workspace_uid=workspace_uid,
+            api_endpoint=api_endpoint,
+        )
 
         check_for_new_version()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "paradime-io"
-version = "5.12.0"
+version = "6.0.0"
 description = "Paradime - Python SDK"
 authors = [
     { name = "Bhuvan Singla", email = "bhuvan@paradime.io" },


### PR DESCRIPTION
## Summary
Adds support for the new bearer-token based authentication methods (company-level and workspace-level tokens) while fully preserving backwards compatibility with the existing API key + secret authentication.

## Changes
- `Paradime`/`APIClient` now auto-detect the auth mode from `api_secret`:
  - A value starting with `prdm_wsp_` or `prdm_cmp_` is treated as a bearer token (`Authorization: Bearer <api_secret>`); `api_key` is not required in this mode.
  - A `prdm_cmp_` (company-level) token additionally requires a new `workspace_uid` parameter, sent as the `X-Paradime-Workspace` header, to select which workspace the request targets.
  - Any other value is treated as a legacy API secret, requiring `api_key` as before — wire format unchanged.
- CLI (`paradime login` and env-var resolution in `get_cli_client`) updated to support both auth styles, including a new `PARADIME_WORKSPACE_UID` env var.
- README updated with usage examples for both auth styles.
- Version bumped to 5.13.0.

## Backwards compatibility
Existing `Paradime(api_key=..., api_secret=...)` usage and `PARADIME_API_KEY`/`PARADIME_API_SECRET` env vars are completely unchanged.