### PR TITLE
Sync Bolt schedule API with current backend GraphQL schema

### DIFF
--- a/paradime/apis/bolt/client.py
+++ b/paradime/apis/bolt/client.py
@@ -271,7 +271,7 @@ class BoltClient:
         """
 
         schedule_input: Dict[str, Any] = {
-            "displayName": display_name,
+            "name": display_name,
             "schedule": schedule,
             "environment": environment,
             "commands": commands,
@@ -359,7 +359,6 @@ class BoltClient:
                     schedules {
                         name
                         slug
-                        displayName
                         schedule
                         owner
                         lastRunAt
@@ -371,11 +370,13 @@ class BoltClient:
                         turboCi {
                             enabled
                             deferredScheduleName
+                            deferredScheduleSlug
                             successfulRunOnly
                         }
                         deferredSchedule {
                             enabled
                             deferredScheduleName
+                            deferredScheduleSlug
                             successfulRunOnly
                         }
                         commands
@@ -421,7 +422,6 @@ class BoltClient:
                 BoltSchedule(
                     name=schedule_json["name"],
                     slug=schedule_json.get("slug"),
-                    display_name=schedule_json.get("displayName"),
                     schedule=schedule_json["schedule"],
                     owner=schedule_json["owner"],
                     last_run_at=schedule_json["lastRunAt"],
@@ -436,6 +436,9 @@ class BoltClient:
                             deferred_schedule_name=schedule_json["deferredSchedule"][
                                 "deferredScheduleName"
                             ],
+                            deferred_schedule_slug=schedule_json["deferredSchedule"].get(
+                                "deferredScheduleSlug"
+                            ),
                             successful_run_only=schedule_json["deferredSchedule"][
                                 "successfulRunOnly"
                             ],
@@ -447,6 +450,9 @@ class BoltClient:
                         BoltDeferredSchedule(
                             enabled=schedule_json["turboCi"]["enabled"],
                             deferred_schedule_name=schedule_json["turboCi"]["deferredScheduleName"],
+                            deferred_schedule_slug=schedule_json["turboCi"].get(
+                                "deferredScheduleSlug"
+                            ),
                             successful_run_only=schedule_json["turboCi"]["successfulRunOnly"],
                         )
                         if schedule_json["turboCi"]

--- a/paradime/apis/bolt/types.py
+++ b/paradime/apis/bolt/types.py
@@ -24,6 +24,7 @@ class BoltRunState(str, Enum):
 class BoltDeferredSchedule(BaseModel):
     enabled: bool
     deferred_schedule_name: Optional[str]
+    deferred_schedule_slug: Optional[str]
     successful_run_only: bool
 
 
@@ -43,7 +44,6 @@ class BoltNotifications(BaseModel):
 class BoltSchedule(BaseModel):
     name: str
     slug: Optional[str]
-    display_name: Optional[str]
     schedule: str
     owner: Optional[str]
     last_run_at: Optional[str]
@@ -243,6 +243,9 @@ class BoltDeferredScheduleConfigInput(_BoltInputBase):
     enabled: bool
     successful_run_only: bool
     deferred_schedule_name: Optional[str] = None
+    """Deprecated alias for ``deferred_schedule_slug``. Carries a slug, not a display name."""
+    deferred_schedule_slug: Optional[str] = None
+    """Slug of the deferred-to schedule. Takes priority over ``deferred_schedule_name``."""
 
 
 class BoltScheduleTriggerInput(_BoltInputBase):

--- a/paradime/cli/bolt.py
+++ b/paradime/cli/bolt.py
@@ -396,7 +396,7 @@ def migrate(path: str) -> None:
     for s in all_schedules.schedules:
         db_schedules[s.name] = {
             "slug": s.slug,
-            "display_name": s.display_name,
+            "display_name": s.name,
         }
 
     root = schedule_path.parent if schedule_path.is_file() else schedule_path


### PR DESCRIPTION
Fixes two bugs where the Bolt client would fail against the current backend, plus a parity addition:

- `list_schedules()`: removed the `displayName` field from the GraphQL query and the `display_name` attribute from the `BoltSchedule` model — it no longer exists on the backend (only `name` and `slug` do).
- `create_schedule()`: fixed the input payload to send `name` instead of the non-existent `displayName` field, which would be rejected as an unknown input field.
- Added `deferred_schedule_slug` to `BoltDeferredSchedule` and `BoltDeferredScheduleConfigInput`, matching the `deferredScheduleSlug` field now present on the backend for both `deferred_schedule`/`turbo_ci`.

Also updates the schedule-migration CLI command, which read `display_name` off the removed field, to use `name` instead.