### PR TITLE
Expose `suspended` (paused) state on Bolt schedules

### DIFF
--- a/examples/bolt/list_schedules.py
+++ b/examples/bolt/list_schedules.py
@@ -6,3 +6,14 @@ paradime = Paradime(api_endpoint="API_ENDPOINT", api_key="API_KEY", api_secret="
 
 # List all schedules
 schedules = paradime.bolt.list_schedules().schedules
+
+# Each schedule exposes its paused state
+for s in schedules:
+    print(s.slug, "suspended" if s.suspended else "active")
+
+# Filter by paused (suspended) state server-side:
+#   suspended=True  -> only paused schedules
+#   suspended=False -> only active (non-paused) schedules
+#   suspended=None  -> all schedules (default)
+paused_schedules = paradime.bolt.list_schedules(suspended=True).schedules
+

--- a/examples/bolt/list_schedules.py
+++ b/examples/bolt/list_schedules.py
@@ -16,4 +16,3 @@ for s in schedules:
 #   suspended=False -> only active (non-paused) schedules
 #   suspended=None  -> all schedules (default)
 paused_schedules = paradime.bolt.list_schedules(suspended=True).schedules
-

--- a/paradime/apis/bolt/client.py
+++ b/paradime/apis/bolt/client.py
@@ -343,6 +343,7 @@ class BoltClient:
         offset: int = 0,
         limit: int = 100,
         show_inactive: bool = False,
+        suspended: Optional[bool] = None,
     ) -> BoltSchedules:
         """
         Get a list of Bolt schedules. The list is paginated. The total count of schedules is also returned.
@@ -351,14 +352,17 @@ class BoltClient:
             offset (int): The offset value for pagination. Default is 0.
             limit (int): The limit value for pagination. Default is 100.
             show_inactive (bool): Flag to indicate whether to return inactive schedules instead of active schedules. Default is False.
+            suspended (Optional[bool]): Filter by paused (suspended) state. Leave as None to
+                return all schedules; pass True for only paused schedules, or False for only
+                active (non-paused) schedules. Default is None.
 
         Returns:
             BoltSchedules: An object containing the list of Bolt schedules and the total count of schedules.
         """
 
         query = """
-            query listBoltSchedules($offset: Int!, $limit: Int!, $showInactive: Boolean!) {
-                listBoltSchedules(offset: $offset, limit: $limit, showInactive: $showInactive) {
+            query listBoltSchedules($offset: Int!, $limit: Int!, $showInactive: Boolean!, $filter: BoltScheduleFilter) {
+                listBoltSchedules(offset: $offset, limit: $limit, showInactive: $showInactive, filter: $filter) {
                     schedules {
                         name
                         slug
@@ -370,6 +374,7 @@ class BoltClient:
                         id
                         uuid
                         source
+                        suspended
                         turboCi {
                             enabled
                             deferredScheduleName
@@ -414,9 +419,18 @@ class BoltClient:
             }
         """
 
+        # Only send the filter object when a value is provided; omitting it (null)
+        # returns all schedules regardless of paused state.
+        schedule_filter = None if suspended is None else {"suspended": suspended}
+
         response_json = self.client._call_gql(
             query=query,
-            variables={"offset": offset, "limit": limit, "showInactive": show_inactive},
+            variables={
+                "offset": offset,
+                "limit": limit,
+                "showInactive": show_inactive,
+                "filter": schedule_filter,
+            },
         )["listBoltSchedules"]
 
         schedules: List[BoltSchedule] = []
@@ -433,6 +447,7 @@ class BoltClient:
                     id=schedule_json["id"],
                     uuid=schedule_json["uuid"],
                     source=schedule_json["source"],
+                    suspended=schedule_json["suspended"],
                     deferred_schedule=(
                         BoltDeferredSchedule(
                             enabled=schedule_json["deferredSchedule"]["enabled"],
@@ -592,6 +607,7 @@ class BoltClient:
                     schedule
                     uuid
                     source
+                    suspended
                 }
             }
         """
@@ -608,6 +624,7 @@ class BoltClient:
             source=response_json["source"],
             owner=response_json["owner"],
             latest_run_id=response_json["latestRunId"],
+            suspended=response_json["suspended"],
         )
 
     def get_run_status(self, run_id: int) -> Optional[BoltRunState]:

--- a/paradime/apis/bolt/types.py
+++ b/paradime/apis/bolt/types.py
@@ -52,6 +52,7 @@ class BoltSchedule(BaseModel):
     id: int
     uuid: str
     source: str
+    suspended: bool
     deferred_schedule: Optional[BoltDeferredSchedule]
     turbo_ci: Optional[BoltDeferredSchedule]
     commands: Optional[List[str]]
@@ -76,6 +77,7 @@ class BoltScheduleInfo(BaseModel):
     source: str
     owner: Optional[str]
     latest_run_id: Optional[int]
+    suspended: bool
 
 
 class BoltCommand(BaseModel):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "paradime-io"
-version = "6.1.0"
+version = "6.2.0"
 description = "Paradime - Python SDK"
 authors = [
     { name = "Bhuvan Singla", email = "bhuvan@paradime.io" },


### PR DESCRIPTION
## What

Adds support for the new `suspended` (paused) field that the Paradime backend now exposes on the Bolt schedule API (backend PR paradime-io/paradime-backend#3636).

## Changes

- **`BoltSchedule` / `BoltScheduleInfo`** (`paradime/apis/bolt/types.py`) — new non-optional `suspended: bool` field.
- **`list_schedules()`** (`paradime/apis/bolt/client.py`):
  - Selects the new `suspended` field on each schedule.
  - New optional `suspended: Optional[bool] = None` parameter that maps to the backend's `filter: BoltScheduleFilter { suspended }`. The `filter` variable is only sent when a value is provided, so the default behavior (all schedules) is unchanged.
- **`get_schedule()`** — selects and returns `suspended` on `BoltScheduleInfo`.
- **Example** (`examples/bolt/list_schedules.py`) — shows reading `s.suspended` and filtering with `list_schedules(suspended=True)`.

## Filter semantics (`list_schedules`)

| `suspended` | Returns |
|-------------|---------|
| `None` (default) | all schedules (unchanged) |
| `True` | only paused schedules |
| `False` | only active (non-paused) schedules |

## Notes

- No CLI command was added — the CLI had no schedule-listing command before, and the field/filter is fully usable via the SDK. Kept the CLI surface unchanged.
- Requires the backend change (#3636) to be deployed, since it sends the `filter: BoltScheduleFilter` variable and selects the `suspended` field.

## How to test

```python
from paradime import Paradime
paradime = Paradime(api_endpoint="...", api_key="...", api_secret="...")

# Read paused state
for s in paradime.bolt.list_schedules().schedules:
    print(s.slug, s.suspended)

# Server-side filter
paused = paradime.bolt.list_schedules(suspended=True).schedules
active = paradime.bolt.list_schedules(suspended=False).schedules
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)