### PR TITLE
[ENG-3513] Accept object-form commands + continue_on_error in schedule validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,13 @@ lint:
 	ruff check . --fix
 	flake8 .
 
+test:
+	pytest tests
+
 verify:
 	black --check .
 	isort --check-only .
 	mypy . --exclude dist
 	ruff check .
 	flake8 .
+	pytest tests

--- a/paradime/core/bolt/schedule.py
+++ b/paradime/core/bolt/schedule.py
@@ -218,6 +218,11 @@ class Integrations(BaseModel):
         extra = Extra.allow
 
 
+class CommandSetting(ParadimeScheduleBase):
+    # Keep in sync with the paradime-backend `CommandSetting`.
+    continue_on_error: Optional[bool] = None
+
+
 class ParadimeSchedule(ParadimeScheduleBase):
     name: str
     slug: Optional[str] = None
@@ -226,6 +231,10 @@ class ParadimeSchedule(ParadimeScheduleBase):
     timezone: Optional[str] = None
     environment: str
     commands: List[str]
+    # Keep in sync with the paradime-backend `ParadimeSchedule`: schedule-level
+    # default plus per-command settings aligned index-by-index with `commands`.
+    continue_on_error: Optional[bool] = False
+    command_settings: Optional[List[CommandSetting]] = None
 
     git_branch: Optional[str] = None
     owner_email: Optional[str] = None
@@ -252,6 +261,63 @@ class ParadimeSchedule(ParadimeScheduleBase):
     trigger_on_merge: Optional[bool] = False
 
     suspended: Optional[bool] = False
+
+    @root_validator(pre=True)
+    @classmethod
+    def normalize_commands(cls, values: Any) -> Any:
+        # Keep in sync with the paradime-backend `ParadimeSchedule`. A command
+        # entry may be a bare string or `{command: <str>, continue_on_error: <bool>}`;
+        # normalize object entries into `commands` + `command_settings` before
+        # field validation so `Extra.forbid` never sees the dicts.
+        if not isinstance(values, dict):
+            return values
+        commands = values.get("commands")
+        if not isinstance(commands, list):
+            return values
+
+        has_object_form = any(isinstance(command, dict) for command in commands)
+        if not has_object_form:
+            return values
+        if values.get("command_settings") is not None:
+            raise ValueError(
+                "Use either object-form command entries or 'command_settings', not both"
+            )
+
+        normalized_commands: List[Any] = []
+        settings: List[Any] = []
+        allowed_keys = {"command", "continue_on_error"}
+        for command in commands:
+            if isinstance(command, dict):
+                unknown_keys = set(command) - allowed_keys
+                if "command" not in command or unknown_keys:
+                    raise ValueError(
+                        f"Invalid command entry {command!r}: a command must be a string or an "
+                        "object with a 'command' key and an optional 'continue_on_error' key"
+                    )
+                normalized_commands.append(command["command"])
+                settings.append({"continue_on_error": command.get("continue_on_error")})
+            else:
+                normalized_commands.append(command)
+                settings.append({"continue_on_error": None})
+        values["commands"] = normalized_commands
+        values["command_settings"] = settings
+        return values
+
+    @root_validator()
+    @classmethod
+    def validate_command_settings_length(cls, values: Any) -> Any:
+        command_settings = values.get("command_settings")
+        commands = values.get("commands")
+        if (
+            command_settings is not None
+            and commands is not None
+            and len(command_settings) != len(commands)
+        ):
+            raise ValueError(
+                f"'command_settings' length ({len(command_settings)}) must match "
+                f"'commands' length ({len(commands)})"
+            )
+        return values
 
     @validator("display_name")
     def validate_display_name(cls, display_name: Optional[str]) -> Optional[str]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dev = [
     "isort>=5.13.2,<6.0.0",
     "ruff>=0.3.5,<0.4.0",
     "flake8>=7.1.0,<8.0.0",
+    "pytest>=8.0.0,<9.0.0",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -1,0 +1,190 @@
+from pathlib import Path
+from typing import Any, Dict, List
+
+import pytest
+
+from paradime.core.bolt.schedule import CommandSetting, ParadimeSchedule, is_valid_schedule_at_path
+from paradime.core.bolt.yaml_rewriter import mint_slugs_in_yaml_files
+
+
+def _schedule(commands: List[Any], **overrides: Any) -> Dict[str, Any]:
+    base: Dict[str, Any] = {
+        "name": "nightly-run",
+        "schedule": "0 0 * * *",
+        "environment": "production",
+        "commands": commands,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_bare_string_commands_unchanged() -> None:
+    schedule = ParadimeSchedule.parse_obj(_schedule(["dbt seed", "dbt run"]))
+    assert schedule.commands == ["dbt seed", "dbt run"]
+    assert schedule.command_settings is None
+    assert schedule.continue_on_error is False
+
+
+def test_mixed_commands_normalized() -> None:
+    schedule = ParadimeSchedule.parse_obj(
+        _schedule(
+            [
+                "dbt seed",
+                {"command": "dbt run", "continue_on_error": True},
+                "dbt test",
+            ]
+        )
+    )
+    assert schedule.commands == ["dbt seed", "dbt run", "dbt test"]
+    assert schedule.command_settings is not None
+    assert [setting.continue_on_error for setting in schedule.command_settings] == [
+        None,
+        True,
+        None,
+    ]
+
+
+def test_per_command_override_false() -> None:
+    schedule = ParadimeSchedule.parse_obj(
+        _schedule(
+            [
+                {"command": "dbt run", "continue_on_error": False},
+                {"command": "dbt test"},
+            ],
+            continue_on_error=True,
+        )
+    )
+    assert schedule.continue_on_error is True
+    assert schedule.commands == ["dbt run", "dbt test"]
+    assert schedule.command_settings is not None
+    assert [setting.continue_on_error for setting in schedule.command_settings] == [False, None]
+
+
+def test_object_command_unknown_key_rejected() -> None:
+    with pytest.raises(Exception, match="continue_on_error"):
+        ParadimeSchedule.parse_obj(_schedule([{"command": "dbt run", "continue_on_err": True}]))
+
+
+def test_object_command_missing_command_key_rejected() -> None:
+    with pytest.raises(Exception, match="'command'"):
+        ParadimeSchedule.parse_obj(_schedule([{"continue_on_error": True}]))
+
+
+def test_schedule_level_continue_on_error() -> None:
+    schedule = ParadimeSchedule.parse_obj(_schedule(["dbt build"], continue_on_error=True))
+    assert schedule.continue_on_error is True
+    assert schedule.commands == ["dbt build"]
+    assert schedule.command_settings is None
+
+
+def test_command_settings_passed_directly() -> None:
+    schedule = ParadimeSchedule.parse_obj(
+        _schedule(
+            ["dbt run", "dbt test"],
+            command_settings=[{"continue_on_error": True}, {"continue_on_error": None}],
+        )
+    )
+    assert schedule.command_settings == [
+        CommandSetting(continue_on_error=True),
+        CommandSetting(continue_on_error=None),
+    ]
+
+
+def test_command_settings_length_mismatch_rejected() -> None:
+    with pytest.raises(Exception, match="length"):
+        ParadimeSchedule.parse_obj(
+            _schedule(
+                ["dbt run", "dbt test"],
+                command_settings=[{"continue_on_error": True}],
+            )
+        )
+
+
+def test_object_commands_with_direct_command_settings_rejected() -> None:
+    with pytest.raises(Exception, match="not both"):
+        ParadimeSchedule.parse_obj(
+            _schedule(
+                [{"command": "dbt run", "continue_on_error": True}],
+                command_settings=[{"continue_on_error": False}],
+            )
+        )
+
+
+def test_json_round_trip_keeps_commands_as_strings() -> None:
+    schedule = ParadimeSchedule.parse_obj(
+        _schedule(
+            ["dbt seed", {"command": "dbt run", "continue_on_error": True}],
+            continue_on_error=True,
+        )
+    )
+    reparsed = ParadimeSchedule.parse_obj(schedule.dict())
+    assert reparsed.commands == ["dbt seed", "dbt run"]
+    assert reparsed.command_settings == schedule.command_settings
+    assert reparsed.continue_on_error is True
+
+
+def test_is_valid_schedule_at_path_accepts_object_form(tmp_path: Path) -> None:
+    yaml_file = tmp_path / "paradime_schedules.yml"
+    yaml_file.write_text(
+        """
+schedules:
+  - name: nightly-run
+    schedule: "0 0 * * *"
+    environment: production
+    continue_on_error: true
+    commands:
+      - dbt seed
+      - command: "dbt run"
+        continue_on_error: false
+      - dbt test
+"""
+    )
+    assert is_valid_schedule_at_path(yaml_file) is None
+
+
+def test_is_valid_schedule_at_path_rejects_unknown_command_key(tmp_path: Path) -> None:
+    yaml_file = tmp_path / "paradime_schedules.yml"
+    yaml_file.write_text(
+        """
+schedules:
+  - name: nightly-run
+    schedule: "0 0 * * *"
+    environment: production
+    commands:
+      - command: "dbt run"
+        continue_on_failure: true
+"""
+    )
+    error = is_valid_schedule_at_path(yaml_file)
+    assert error is not None
+    assert "continue_on_failure" in error
+
+
+def test_mint_slugs_round_trips_object_form_commands(tmp_path: Path) -> None:
+    yaml_file = tmp_path / "paradime_schedules.yml"
+    yaml_file.write_text(
+        """schedules:
+  - name: My Nightly Run
+    schedule: "0 0 * * *"
+    environment: production
+    continue_on_error: true
+    commands:
+      - dbt seed
+      - command: "dbt run"
+        continue_on_error: false
+      - dbt test
+"""
+    )
+
+    changed = mint_slugs_in_yaml_files(
+        mint_fn=lambda names: [f"minted-{i}" for i, _ in enumerate(names)],
+        root=tmp_path,
+    )
+    assert changed == 1
+
+    rewritten = yaml_file.read_text()
+    assert "slug: minted-0" in rewritten
+    # Object-form command entries must survive the rewrite unmangled.
+    assert 'command: "dbt run"' in rewritten
+    assert "continue_on_error: false" in rewritten
+    assert is_valid_schedule_at_path(yaml_file) is None

--- a/uv.lock
+++ b/uv.lock
@@ -633,6 +633,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "isort"
 version = "5.13.2"
 source = { registry = "https://pypi.org/simple" }
@@ -916,7 +925,7 @@ wheels = [
 
 [[package]]
 name = "paradime-io"
-version = "6.3.0"
+version = "6.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },
@@ -952,6 +961,7 @@ dev = [
     { name = "flake8" },
     { name = "isort" },
     { name = "mypy" },
+    { name = "pytest" },
     { name = "ruff" },
     { name = "types-protobuf" },
     { name = "types-requests" },
@@ -992,6 +1002,7 @@ dev = [
     { name = "flake8", specifier = ">=7.1.0,<8.0.0" },
     { name = "isort", specifier = ">=5.13.2,<6.0.0" },
     { name = "mypy", specifier = ">=1.8.0,<2.0.0" },
+    { name = "pytest", specifier = ">=8.0.0,<9.0.0" },
     { name = "ruff", specifier = ">=0.3.5,<0.4.0" },
     { name = "types-protobuf", specifier = ">=5.26.0,<6.0.0" },
     { name = "types-requests", specifier = ">=2.31.0,<3.0.0" },
@@ -1013,6 +1024,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -1283,6 +1303,22 @@ wheels = [
 [package.optional-dependencies]
 crypto = [
     { name = "cryptography" },
+]
+
+[[package]]
+name = "pytest"
+version = "8.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Context

The backend is adding a Bolt `continue_on_error` feature (paradime-io/paradime-backend#3668, design doc Phase 1a): a schedules-YAML command entry may now be either a bare string **or** an object `{command: <str>, continue_on_error: <bool>}`, and schedules gain a schedule-level `continue_on_error: bool` (default `false`).

The SDK's local validator (`ParadimeSchedule`, used by `paradime bolt verify` / `is_valid_schedule_at_path`) declares `commands: List[str]` under `Extra.forbid`, so it **hard-rejects** the new YAML shape. This PR mirrors the backend Phase 1a change so the SDK accepts it.

Linear: [ENG-3513](https://linear.app/building-paradime/issue/ENG-3513)

> **Release note:** this must release before/with customer rollout of the new YAML shape — older SDK versions reject it.

## Changes

- `paradime/core/bolt/schedule.py`
  - New `CommandSetting(ParadimeScheduleBase)` with `continue_on_error: Optional[bool] = None` (kept in sync with the backend model).
  - `ParadimeSchedule`: new `continue_on_error: Optional[bool] = False` (schedule-level default) and `command_settings: Optional[List[CommandSetting]] = None` (index-aligned with `commands`); `commands: List[str]` unchanged.
  - A `pre=True` root_validator normalizes a mixed commands list before field validation: object entries must have exactly `{command}` or `{command, continue_on_error}` (unknown keys rejected with a clear error, matching the repo's `Extra.forbid` posture); strings are extracted into `commands` and per-command flags into `command_settings` (`None` for bare strings). `command_settings` may also be passed directly (model/JSON round-trip); mixing both forms is rejected; `len(command_settings) == len(commands)` is enforced.
- `paradime/core/bolt/yaml_rewriter.py`: verified (via test) that `mint_slugs_in_yaml_files` round-trips object-form command entries unmangled — the rewriter never touches `commands`, and ruamel preserves the entries as-is. No code change needed.
- Tests: added `tests/test_schedule.py` (13 tests — bare strings unchanged, mixed list, per-command override, unknown-key/missing-key rejection, schedule-level flag, direct `command_settings` + length mismatch, `.dict()` round-trip, `is_valid_schedule_at_path` accept/reject, yaml_rewriter round-trip). The repo had no pytest setup, so this adds `pytest` to the dev dependency group and wires `pytest tests` into `make verify` (run by CI) plus a `make test` target.

Out of scope (follow-up): API client wrappers (`trigger_run` etc.).

## Test results

`uv run make verify`: black, isort, mypy (142 files, no issues), ruff, flake8 all clean; `pytest tests` — 13 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
